### PR TITLE
:unamused: chore: meteor add hot-module-replacement

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -24,3 +24,4 @@ underscore@1.0.10
 ostrio:files
 dburles:factory
 static-html
+hot-module-replacement

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -31,6 +31,7 @@ es5-shim@4.8.0
 fetch@0.1.1
 geojson-utils@1.0.10
 hot-code-push@1.0.4
+hot-module-replacement@0.2.0
 html-tools@1.0.11
 htmljs@1.0.11
 http@1.4.3
@@ -53,6 +54,7 @@ mobile-status-bar@1.1.0
 modern-browsers@0.1.5
 modules@0.16.0
 modules-runtime@0.12.0
+modules-runtime-hot@0.13.0
 mongo@1.10.1
 mongo-decimal@0.1.2
 mongo-dev-server@1.1.0


### PR DESCRIPTION
The dev console complains about core-js not being found. See #215 for backlog. Fixes #210.