### PR TITLE
Increase test timeout for `ci:build:compose` workflow

### DIFF
--- a/.github/workflows/ci:build:compose.yml
+++ b/.github/workflows/ci:build:compose.yml
@@ -68,7 +68,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
-    timeout-minutes: 3
+    timeout-minutes: 4
 
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
Three minutes was just not enough.