### PR TITLE
Increase timeout of `test` job in `ci:build` workflow to 3 minutes

### DIFF
--- a/.github/workflows/ci:build.yml
+++ b/.github/workflows/ci:build.yml
@@ -82,7 +82,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
-    timeout-minutes: 2
+    timeout-minutes: 3
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Two minutes was just not enough.