### PR TITLE
Pin `pdfjs-dist` to `v3.11.174`

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "meteor-node-stubs": "^1.2.5",
     "notistack": "^3.0.1",
     "papaparse": "^5.4.1",
-    "pdfjs-dist": "~3.11.0",
+    "pdfjs-dist": "~3.11.174",
     "qrcode.react": "^3.1.0",
     "rate-limiter-flexible": "^3.0.0",
     "react": "^18.2.0",


### PR DESCRIPTION
Already enforced by `package-lock.json`.