### PR TITLE
Fix CVE-2024-4367

### DIFF
--- a/imports/lib/pdf/pdf.ts
+++ b/imports/lib/pdf/pdf.ts
@@ -15,6 +15,7 @@ export async function fetchPDF({
 	cMapUrl = CMAP_URL,
 	cMapPacked = CMAP_PACKED,
 	standardFontDataUrl = STANDARD_FONT_DATA_URL,
+	isEvalSupported = false,
 	...rest
 }: DocumentInitParameters) {
 	const pdfjs = Meteor.isClient
@@ -27,8 +28,13 @@ export async function fetchPDF({
 		// pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 	}
 
-	return pdfjs.getDocument({cMapUrl, cMapPacked, standardFontDataUrl, ...rest})
-		.promise;
+	return pdfjs.getDocument({
+		cMapUrl,
+		cMapPacked,
+		standardFontDataUrl,
+		isEvalSupported,
+		...rest,
+	}).promise;
 }
 
 export async function saveHTMLElementAsPDF(

--- a/imports/lib/pdf/pdf.ts
+++ b/imports/lib/pdf/pdf.ts
@@ -1,5 +1,8 @@
 import {type DocumentInitParameters} from 'pdfjs-dist/types/src/display/api';
 
+export {type DocumentInitParameters} from 'pdfjs-dist/types/src/display/api';
+export {type PageViewport} from 'pdfjs-dist/types/src/display/display_utils';
+
 export const WORKER_URL = Meteor.isClient
 	? '/pdfjs-dist/build/pdf.worker.min.js'
 	: 'pdfjs-dist/legacy/build/pdf.worker.js';

--- a/imports/lib/pdf/pdfthumbnails.ts
+++ b/imports/lib/pdf/pdfthumbnails.ts
@@ -9,12 +9,10 @@ import {
 	type PngConfig,
 } from 'canvas/types';
 import addDays from 'date-fns/addDays';
-import {type DocumentInitParameters} from 'pdfjs-dist/types/src/display/api';
-import {type PageViewport} from 'pdfjs-dist/types/src/display/display_utils';
 
 import {cache as lru, type IndexedDBPersistedLRUCache} from '../cache/lru';
 
-import {fetchPDF} from './pdf';
+import {type DocumentInitParameters, type PageViewport, fetchPDF} from './pdf';
 
 let cache: IndexedDBPersistedLRUCache<string, string>;
 if (Meteor.isClient) {


### PR DESCRIPTION
By default, `pdfjs-dist` optimizes some path resolution logic by compiling a JavaScript function on the fly. The function is built using string concatenation and no effort is made at sanitizing the parts it is built from. These parts could contain user-input which leads to a code injection vulnerability. This commit disables this default behavior. An alternative is to upgrade `pdfjs-dist` to v4.2.67 or later.

See:
  - https://bugzilla.mozilla.org/show_bug.cgi?id=1893645
  - https://www.cve.org/CVERecord?id=CVE-2024-4367
  - https://security.snyk.io/vuln/SNYK-JS-PDFJSDIST-6810403
  - https://github.com/advisories/GHSA-wgrm-67xf-hhpq
  - https://github.com/mozilla/pdf.js/security/advisories/GHSA-wgrm-67xf-hhpq
  - https://github.com/mozilla/pdf.js/pull/18015
  - https://github.com/wojtekmaj/react-pdf/discussions/1786
  - https://security.stackexchange.com/questions/248462/is-firefoxs-new-javascript-support-within-pdf-files-a-security-concern/248985#248985
  - https://stackoverflow.com/questions/49299000/what-are-the-security-implications-of-the-isevalsupported-option-in-pdf-js
  - https://github.com/mozilla/pdf.js/issues/10818
