### PR TITLE
Increase compose workflow test job timeout to 5 minutes

### DIFF
--- a/.github/workflows/ci:build:compose.yml
+++ b/.github/workflows/ci:build:compose.yml
@@ -68,7 +68,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
-    timeout-minutes: 4
+    timeout-minutes: 5
 
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
We can easily reach 4 minutes if we do not hit the build cache.