### PR TITLE
Upgrade `pdfjs-dist` to v3.5

### DIFF
--- a/imports/util/canvas.ts
+++ b/imports/util/canvas.ts
@@ -1,11 +1,11 @@
-import {type Canvas} from 'canvas/types';
+import {type Canvas} from 'canvas';
 
 export {
 	type Canvas,
 	type JpegConfig,
 	type PdfConfig,
 	type PngConfig,
-} from 'canvas/types';
+} from 'canvas';
 
 type CreateCanvasOptions = {
 	width: number;

--- a/imports/util/pdf/pdf.ts
+++ b/imports/util/pdf/pdf.ts
@@ -5,7 +5,7 @@ export {type PageViewport} from 'pdfjs-dist/types/src/display/display_utils';
 
 export const WORKER_URL = Meteor.isClient
 	? '/pdfjs-dist/build/pdf.worker.min.js'
-	: 'pdfjs-dist/legacy/build/pdf.worker.js';
+	: './pdf.worker.js';
 export const CMAP_URL = Meteor.isClient
 	? '/pdfjs-dist/cmaps/'
 	: './npm/node_modules/pdfjs-dist/cmaps/';
@@ -14,6 +14,11 @@ export const STANDARD_FONT_DATA_URL = Meteor.isClient
 	? '/pdfjs-dist/standard_fonts/'
 	: './npm/node_modules/pdfjs-dist/standard_fonts/';
 
+export const _embedWoker = async () => {
+	// NOTE: This forces Meteor to embed the worker in the server build.
+	if (Meteor.isServer) await import('./pdfjs-dist/pdf.worker.js');
+};
+
 export async function fetchPDF({
 	cMapUrl = CMAP_URL,
 	cMapPacked = CMAP_PACKED,
@@ -21,9 +26,7 @@ export async function fetchPDF({
 	isEvalSupported = false,
 	...rest
 }: DocumentInitParameters) {
-	const pdfjs = Meteor.isClient
-		? await import('pdfjs-dist')
-		: await import('pdfjs-dist/legacy/build/pdf.js');
+	const pdfjs = await import('./pdfjs-dist/pdf.js');
 
 	if (pdfjs.GlobalWorkerOptions.workerSrc === '') {
 		pdfjs.GlobalWorkerOptions.workerSrc = WORKER_URL;

--- a/imports/util/pdf/pdfjs-dist
+++ b/imports/util/pdf/pdfjs-dist
@@ -1,0 +1,1 @@
+../../../node_modules/pdfjs-dist/legacy/build

--- a/package-lock.json
+++ b/package-lock.json
@@ -2233,6 +2233,21 @@
           "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
           "dev": true
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "emoji-regex": {
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -2250,6 +2265,40 @@
             "strip-ansi": "^7.0.1"
           }
         },
+        "string-width-cjs": {
+          "version": "npm:string-width@4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+              "dev": true
+            },
+            "emoji-regex": {
+              "version": "8.0.0",
+              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            }
+          }
+        },
         "strip-ansi": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -2257,6 +2306,23 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^6.0.1"
+          }
+        },
+        "strip-ansi-cjs": {
+          "version": "npm:strip-ansi@6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+              "dev": true
+            }
           }
         },
         "wrap-ansi": {
@@ -2268,6 +2334,60 @@
             "ansi-styles": "^6.1.0",
             "string-width": "^5.0.1",
             "strip-ansi": "^7.0.1"
+          }
+        },
+        "wrap-ansi-cjs": {
+          "version": "npm:wrap-ansi@7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "emoji-regex": {
+              "version": "8.0.0",
+              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+              "dev": true
+            },
+            "string-width": {
+              "version": "4.2.3",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+              "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            }
           }
         }
       }
@@ -16150,17 +16270,6 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "string-width-cjs": {
-      "version": "npm:string-width@4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      }
-    },
     "string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -16815,15 +16924,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      }
-    },
-    "strip-ansi-cjs": {
-      "version": "npm:strip-ansi@6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -17766,43 +17866,6 @@
     },
     "wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
-      }
-    },
-    "wrap-ansi-cjs": {
-      "version": "npm:wrap-ansi@7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13741,9 +13741,9 @@
       "dev": true
     },
     "pdfjs-dist": {
-      "version": "3.4.120",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.4.120.tgz",
-      "integrity": "sha512-B1hw9ilLG4m/jNeFA0C2A0PZydjxslP8ylU+I4XM7Bzh/xWETo9EiBV848lh0O0hLut7T6lK1V7cpAXv5BhxWw==",
+      "version": "3.5.141",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.5.141.tgz",
+      "integrity": "sha512-lYIvyi5grtYOIatsfCifIKwxHeAJ8eHyP22DTdvY4pm0yWVSFQnMafpgCPSw8gaNRDDdcHnBVOkqMsyK8SRxZg==",
       "requires": {
         "canvas": "^2.11.0",
         "path2d-polyfill": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -5,13 +5,6 @@
     "mainModule": {
       "client": "client/main.tsx",
       "server": "server/main.ts"
-    },
-    "nodeModules": {
-      "recompile": {
-        "pdfjs-dist": [
-          "server"
-        ]
-      }
     }
   },
   "postinstall": {
@@ -227,7 +220,8 @@
     "extends": "xo-react",
     "prettier": true,
     "ignores": [
-      "packages/**"
+      "packages/**",
+      "imports/util/pdf/pdfjs-dist/**"
     ],
     "rules": {
       "camelcase": "off",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
     "mainModule": {
       "client": "client/main.tsx",
       "server": "server/main.ts"
+    },
+    "nodeModules": {
+      "recompile": {
+        "pdfjs-dist": [
+          "server"
+        ]
+      }
     }
   },
   "postinstall": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "notistack": "^3.0.1",
     "p-debounce": "^4.0.0",
     "papaparse": "^5.4.1",
-    "pdfjs-dist": "~3.4.120",
+    "pdfjs-dist": "~3.5.141",
     "qrcode.react": "^3.1.0",
     "rate-limiter-flexible": "^4.0.1",
     "react": "^18.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,5 +39,8 @@
     "imports/**/*",
     "test/**/*",
     ".upgrade/**/*"
+  ],
+  "exclude": [
+    "imports/util/pdf/pdfjs-dist/**/*"
   ]
 }


### PR DESCRIPTION
This is the first version of `pdfjs-dist` that fails because of `SyntaxError: Unexpected token '||='`:

```console
I20240514-04:16:20.691(2)?   1) /imports/lib/pdf/pdf.tests.ts
I20240514-04:16:20.692(2)?        should work on the server:
I20240514-04:16:20.692(2)?      /home/runner/work/patients/patients/node_modules/pdfjs-dist/legacy/build/pdf.js:4907
I20240514-04:16:20.692(2)?     (intentState.renderTasks ||= new Set()).add(internalRenderTask);
I20240514-04:16:20.692(2)?                              ^^^
I20240514-04:16:20.693(2)? 
I20240514-04:16:20.693(2)? SyntaxError: Unexpected token '||='
I20240514-04:16:20.693(2)?       at wrapSafe (internal/modules/cjs/loader.js:1031:16)
I20240514-04:16:20.693(2)?       at Module._compile (internal/modules/cjs/loader.js:1080:27)
I20240514-04:16:20.693(2)?       at Module.Mp._compile (runtime.js:77:23)
I20240514-04:16:20.693(2)?       at Object.Module._extensions..js (runtime.js:105:23)
I20240514-04:16:20.694(2)?       at Module.load (internal/modules/cjs/loader.js:981:32)
I20240514-04:16:20.694(2)?       at Module.Mp.load (runtime.js:37:33)
I20240514-04:16:20.694(2)?       at Function.Module._load (internal/modules/cjs/loader.js:821:12)
I20240514-04:16:20.694(2)?       at Module.require (internal/modules/cjs/loader.js:1005:19)
I20240514-04:16:20.694(2)?       at require (internal/modules/cjs/helpers.js:107:18)
I20240514-04:16:20.694(2)?       at npmRequire (npm-require.js:111:12)
I20240514-04:16:20.694(2)?       at Module.useNode (packages/modules-runtime.js:751:18)
I20240514-04:16:20.694(2)?       at module (packages/modules.js:5156:8)
I20240514-04:16:20.694(2)?       at fileEvaluate (packages/modules-runtime.js:336:7)
I20240514-04:16:20.694(2)?       at Module.require (packages/modules-runtime.js:238:14)
I20240514-04:16:20.694(2)?       at Module.moduleLink [as link] (/home/runner/.meteor/packages/modules/.0.19.0.vw5cu9.x68za++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/@meteorjs/reify/lib/runtime/index.js:52:22)
I20240514-04:16:20.695(2)?       at getNamespace (packages/dynamic-import.js:630:10)
I20240514-04:16:20.695(2)?    => awaited here:
I20240514-04:16:20.695(2)?       at Function.Promise.await (/home/runner/.meteor/packages/promise/.0.12.2.qhmebw.8r9v9++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/promise_server.js:56:12)
I20240514-04:16:20.695(2)?       at imports/lib/pdf/pdf.ts:25:31
I20240514-04:16:20.695(2)?       at /home/runner/.meteor/packages/promise/.0.12.2.qhmebw.8r9v9++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
I20240514-04:16:20.695(2)?    => awaited here:
I20240514-04:16:20.695(2)?       at Function.Promise.await (/home/runner/.meteor/packages/promise/.0.12.2.qhmebw.8r9v9++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/promise_server.js:56:12)
I20240514-04:16:20.695(2)?       at imports/lib/pdf/pdf.tests.ts:16:3
I20240514-04:16:20.695(2)?       at /home/runner/.meteor/packages/promise/.0.12.2.qhmebw.8r9v9++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
```