### PR TITLE
Upgrade `pdfjs-dist` to v3.6

### DIFF
--- a/imports/util/canvas.ts
+++ b/imports/util/canvas.ts
@@ -1,11 +1,11 @@
-import {type Canvas} from 'canvas/types';
+import {type Canvas} from 'canvas';
 
 export {
 	type Canvas,
 	type JpegConfig,
 	type PdfConfig,
 	type PngConfig,
-} from 'canvas/types';
+} from 'canvas';
 
 type CreateCanvasOptions = {
 	width: number;

--- a/imports/util/pdf/pdf.ts
+++ b/imports/util/pdf/pdf.ts
@@ -5,7 +5,7 @@ export {type PageViewport} from 'pdfjs-dist/types/src/display/display_utils';
 
 export const WORKER_URL = Meteor.isClient
 	? '/pdfjs-dist/build/pdf.worker.min.js'
-	: 'pdfjs-dist/legacy/build/pdf.worker.js';
+	: './pdf.worker.js';
 export const CMAP_URL = Meteor.isClient
 	? '/pdfjs-dist/cmaps/'
 	: './npm/node_modules/pdfjs-dist/cmaps/';
@@ -13,6 +13,11 @@ export const CMAP_PACKED = true;
 export const STANDARD_FONT_DATA_URL = Meteor.isClient
 	? '/pdfjs-dist/standard_fonts/'
 	: './npm/node_modules/pdfjs-dist/standard_fonts/';
+
+export const _embedWoker = async () => {
+	// NOTE: This forces Meteor to embed the worker in the server build.
+	if (Meteor.isServer) await import('./pdfjs-dist/pdf.worker.js');
+};
 
 export async function fetchPDF({
 	cMapUrl = CMAP_URL,
@@ -23,7 +28,7 @@ export async function fetchPDF({
 }: DocumentInitParameters) {
 	const pdfjs = Meteor.isClient
 		? await import('pdfjs-dist')
-		: await import('pdfjs-dist/legacy/build/pdf.js');
+		: await import('./pdfjs-dist/pdf.js');
 
 	if (pdfjs.GlobalWorkerOptions.workerSrc === '') {
 		pdfjs.GlobalWorkerOptions.workerSrc = WORKER_URL;

--- a/imports/util/pdf/pdfjs-dist
+++ b/imports/util/pdf/pdfjs-dist
@@ -1,0 +1,1 @@
+../../../node_modules/pdfjs-dist/legacy/build

--- a/package-lock.json
+++ b/package-lock.json
@@ -13861,11 +13861,11 @@
       "dev": true
     },
     "pdfjs-dist": {
-      "version": "3.4.120",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.4.120.tgz",
-      "integrity": "sha512-B1hw9ilLG4m/jNeFA0C2A0PZydjxslP8ylU+I4XM7Bzh/xWETo9EiBV848lh0O0hLut7T6lK1V7cpAXv5BhxWw==",
+      "version": "3.6.172",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.6.172.tgz",
+      "integrity": "sha512-bfOhCg+S9DXh/ImWhWYTOiq3aVMFSCvzGiBzsIJtdMC71kVWDBw7UXr32xh0y56qc5wMVylIeqV3hBaRsu+e+w==",
       "requires": {
-        "canvas": "^2.11.0",
+        "canvas": "^2.11.2",
         "path2d-polyfill": "^2.0.1",
         "web-streams-polyfill": "^3.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "notistack": "^3.0.1",
     "p-debounce": "^4.0.0",
     "papaparse": "^5.4.1",
-    "pdfjs-dist": "~3.4.120",
+    "pdfjs-dist": "~3.6.172",
     "qrcode.react": "^3.1.0",
     "rate-limiter-flexible": "^4.0.1",
     "react": "^18.2.0",
@@ -220,7 +220,8 @@
     "extends": "xo-react",
     "prettier": true,
     "ignores": [
-      "packages/**"
+      "packages/**",
+      "imports/util/pdf/pdfjs-dist/**"
     ],
     "rules": {
       "camelcase": "off",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,5 +39,8 @@
     "imports/**/*",
     "test/**/*",
     ".upgrade/**/*"
+  ],
+  "exclude": [
+    "imports/util/pdf/pdfjs-dist/**/*"
   ]
 }


### PR DESCRIPTION
`pdfjs-dist` requires recompilation with custom babel plugins. Solved by symlinking the imported `node_modules` file into the sources. Had to ignore those in the type-checker and in the linter. See also the discussion at:
  - #944 

```console
I20240514-03:45:53.317(2)?   1) /imports/lib/pdf/pdf.tests.ts
I20240514-03:45:53.318(2)?        should work on the server:
I20240514-03:45:53.318(2)?      /home/runner/work/patients/patients/node_modules/pdfjs-dist/legacy/build/pdf.js:4912
I20240514-03:45:53.318(2)?     (intentState.renderTasks ||= new Set()).add(internalRenderTask);
I20240514-03:45:53.318(2)?                              ^^^
I20240514-03:45:53.318(2)? 
I20240514-03:45:53.318(2)? SyntaxError: Unexpected token '||='
I20240514-03:45:53.318(2)?       at wrapSafe (internal/modules/cjs/loader.js:1031:16)
I20240514-03:45:53.318(2)?       at Module._compile (internal/modules/cjs/loader.js:1080:27)
I20240514-03:45:53.318(2)?       at Module.Mp._compile (runtime.js:77:23)
I20240514-03:45:53.318(2)?       at Object.Module._extensions..js (runtime.js:105:23)
I20240514-03:45:53.319(2)?       at Module.load (internal/modules/cjs/loader.js:981:32)
I20240514-03:45:53.319(2)?       at Module.Mp.load (runtime.js:37:33)
I20240514-03:45:53.319(2)?       at Function.Module._load (internal/modules/cjs/loader.js:821:12)
I20240514-03:45:53.319(2)?       at Module.require (internal/modules/cjs/loader.js:1005:19)
I20240514-03:45:53.319(2)?       at require (internal/modules/cjs/helpers.js:107:18)
I20240514-03:45:53.319(2)?       at npmRequire (npm-require.js:111:12)
I20240514-03:45:53.319(2)?       at Module.useNode (packages/modules-runtime.js:751:18)
I20240514-03:45:53.319(2)?       at module (packages/modules.js:5156:8)
I20240514-03:45:53.319(2)?       at fileEvaluate (packages/modules-runtime.js:336:7)
I20240514-03:45:53.319(2)?       at Module.require (packages/modules-runtime.js:238:14)
I20240514-03:45:53.319(2)?       at Module.moduleLink [as link] (/home/runner/.meteor/packages/modules/.0.19.0.vw5cu9.x68za++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/@meteorjs/reify/lib/runtime/index.js:52:22)
I20240514-03:45:53.319(2)?       at getNamespace (packages/dynamic-import.js:630:10)
I20240514-03:45:53.320(2)?    => awaited here:
I20240514-03:45:53.320(2)?       at Function.Promise.await (/home/runner/.meteor/packages/promise/.0.12.2.qhmebw.8r9v9++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/promise_server.js:56:12)
I20240514-03:45:53.320(2)?       at imports/lib/pdf/pdf.ts:25:31
I20240514-03:45:53.320(2)?       at /home/runner/.meteor/packages/promise/.0.12.2.qhmebw.8r9v9++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
I20240514-03:45:53.320(2)?    => awaited here:
I20240514-03:45:53.320(2)?       at Function.Promise.await (/home/runner/.meteor/packages/promise/.0.12.2.qhmebw.8r9v9++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/promise_server.js:56:12)
I20240514-03:45:53.320(2)?       at imports/lib/pdf/pdf.tests.ts:16:3
I20240514-03:45:53.320(2)?       at /home/runner/.meteor/packages/promise/.0.12.2.qhmebw.8r9v9++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
```