### PR TITLE
Upgrade `pdfjs-dist` to v3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13862,9 +13862,9 @@
       "dev": true
     },
     "pdfjs-dist": {
-      "version": "3.8.162",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.8.162.tgz",
-      "integrity": "sha512-Do0Lpuk1ItcNnIPr9MM+/jnnMOb4i6asRX7gVnL6fFUW1QPC7ERfHQkbhF7jkAri1o6GxttX0Yn7ZhOmpFUeGA==",
+      "version": "3.10.111",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.10.111.tgz",
+      "integrity": "sha512-+SXXGN/3YTNQSK5Ae7EyqQuR+4IAsNunJq/Us5ByOkRJ45qBXXOwkiWi3RIDU+CyF+ak5eSWXl2FQW2PKBrsRA==",
       "requires": {
         "canvas": "^2.11.2",
         "path2d-polyfill": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "notistack": "^3.0.1",
     "p-debounce": "^4.0.0",
     "papaparse": "^5.4.1",
-    "pdfjs-dist": "~3.8.162",
+    "pdfjs-dist": "~3.10.111",
     "qrcode.react": "^3.1.0",
     "rate-limiter-flexible": "^4.0.1",
     "react": "^18.2.0",


### PR DESCRIPTION
- Skipping in favor of #950 because of https://github.com/mozilla/pdf.js/issues/16772.