### PR TITLE
Decrease CI failure rate by tweaking timeouts in `ci:test:deploy` and `ci:build:compose`

### DIFF
--- a/.github/workflows/ci:build:compose.yml
+++ b/.github/workflows/ci:build:compose.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           workflow: ci:build:image.yml
           sha: auto
+          timeout-minutes: 15  # NOTE We build without a fresh cache on timeout.
+          continue-on-error: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci:build:compose.yml
+++ b/.github/workflows/ci:build:compose.yml
@@ -22,7 +22,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/ci:test:deploy.yml
+++ b/.github/workflows/ci:test:deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
-    timeout-minutes: 18
+    timeout-minutes: 30
 
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
Related to #900.