### PR TITLE
Run `ci:test:deploy` on `workflow_run` trigger instead of independently

### DIFF
--- a/.github/workflows/ci:test:deploy.yml
+++ b/.github/workflows/ci:test:deploy.yml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
   merge_group:
+  workflow_run:
+    workflows:
+      - ci:build:image
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -28,7 +33,15 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
+      - name: Fail job if triggering workflow did not succeed
+        if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed('ci:build:image did not succeed')
+
       - name: Wait for image build workflow to succeed
+        if: github.event_name != 'workflow_run'
         uses: ArcticLampyrid/action-wait-for-workflow@v1.2.0
         with:
           workflow: ci:build:image.yml


### PR DESCRIPTION
This PR just adds the trigger. Removing the independent running of the workflow will be done once tested on the default branch.

Progress on #900.