### PR TITLE
Lint `Dockerfile` using `hadolint`

### DIFF
--- a/.github/workflows/ci:lint-dockerfile.yml
+++ b/.github/workflows/ci:lint-dockerfile.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
+      - name: Work around https://github.com/hadolint/hadolint/issues/978
+        run: |
+          grep -v '^  --start-interval=' Dockerfile > Dockerfile.patched
+
       - name: Lint Dockerfile 👕
         run: |
-          npx dockerfilelint ./Dockerfile
+          < ./Dockerfile.patched docker run --rm -i -v ./.hadolint.yaml:/.config/hadolint.yaml hadolint/hadolint

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,5 @@
+failure-threshold: error
+
+trustedRegistries:
+  - docker.io
+  - gcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG PORT=3000
 
 # NOTE Build stage
 
-FROM debian:${DEBIAN_VERSION}-slim AS build
+FROM docker.io/debian:${DEBIAN_VERSION}-slim AS build
 
 
 # NOTE Install build tools


### PR DESCRIPTION
Last release from https://github.com/replicatedhq/dockerfilelint was 5 years ago (1.8.0):
- https://www.npmjs.com/package/dockerfilelint?activeTab=versions

It does not allow build `FROM` named stages:
- https://github.com/replicatedhq/dockerfilelint/issues/197

`hadolint` is the de-facto standard.