### PR TITLE
Add workflow to lint `Dockerfile` using `dockerfilelint`

### DIFF
--- a/.github/workflows/ci:lint-dockerfile.yml
+++ b/.github/workflows/ci:lint-dockerfile.yml
@@ -1,0 +1,26 @@
+name: ci:lint-dockerfile
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+
+  lint:
+    name: Continuous integration (lint dockerfile)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Lint Dockerfile 👕
+        run: |
+          npx dockerfilelint ./Dockerfile


### PR DESCRIPTION
This fixes #969. Since `dockerfilelint` is not really maintained and `hadolint` is a much better option (but cannot be used right now), we run it using `npx` on GHA directly without adding it as a `devDependency` to `package.json`.