### PR TITLE
Configure `restore-keys` for puppeteer cache in `ci:test`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           path: ~/.cache/puppeteer
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-
 
       - name: Install 💾
         uses: ./.github/actions/install


### PR DESCRIPTION
This fixes #865 for good.

Since `meteor-actions/install` now can skip the installation of cached packages using restore keys, it can happen that `node_modules/puppeteer` is restored from cache while its `chromium` download is not.

With this commit, we ensure that the weakest restore key for `chromium` is at least as weak as the weakest restore key for `node_modules/puppeteer`.

Maybe an alternative would be to instruct `puppeteer` to install chromium under `node_modules`? But for now, this is good enough.