### PR TITLE
Do not fail fast on errors in `ci:test` workflow

### DIFF
--- a/.github/workflows/ci:test.yml
+++ b/.github/workflows/ci:test.yml
@@ -17,6 +17,8 @@ jobs:
     name: Continuous integration
     strategy:
 
+      fail-fast: false
+
       matrix:
 
         test-type:


### PR DESCRIPTION
Since fixing #812 with #963, tests are split-run using a strategy matrix, which was not configured with `fail-fast: false` ([the default is `fail-fast: true`](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures)). This PR configures `fail-fast: false` explicitly.