### PR TITLE
Allow `ci:build:compose` build job to run on an old cache

### DIFF
--- a/.github/workflows/ci:build:compose.yml
+++ b/.github/workflows/ci:build:compose.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           workflow: ci:build:image.yml
           sha: auto
-          timeout-minutes: 15  # NOTE We build without a fresh cache on timeout.
-          continue-on-error: true
+        timeout-minutes: 15  # NOTE We build without a fresh cache on timeout.
+        continue-on-error: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Instead of waiting forever on the build to succeed, we build it from a potentially stale cache.

This should have been implemented in 922b7f62e19cd88881d258ab75dfbef7e350e7d3, but due to a typo it had no effect.