### PR TITLE
Downgrade `ical-generator` to v4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10478,9 +10478,9 @@
       "integrity": "sha512-+rocNKk+Ga9m8Lr9fTMWd+87JnsBrucm0ZsIx5ROOarZlaDLmd+FKdbtvb0XyoBw9GAFOYG2GuLqoNB16d+p3w=="
     },
     "ical-generator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-5.0.1.tgz",
-      "integrity": "sha512-ln2cbzi+Z+f9WrWseU4B75Ccwb2hMpgjTYkriSPmqODmOCWNYknTSWiLSrCkl0cHiWcwaTWstMPLDyiFbELmoA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-4.1.0.tgz",
+      "integrity": "sha512-5GrFDJ8SAOj8cB9P1uEZIfKrNxSZ1R2eOQfZePL+CtdWh4RwNXWe8b0goajz+Hu37vcipG3RVldoa2j57Y20IA==",
       "requires": {
         "uuid-random": "^1.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "healthone": "^6.1.0",
     "history": "^5.3.0",
     "iban": "^0.0.14",
-    "ical-generator": "^5.0.1",
+    "ical-generator": "^4.1.0",
     "iconv-lite": "^0.6.3",
     "idb": "^6.1.5",
     "jspdf": "^2.5.1",


### PR DESCRIPTION
`ical-generator` v5 does not officially support Node v14 (https://github.com/sebbo2002/ical-generator/releases/tag/v5.0.0).