### PR TITLE
Improve eid handling

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 71%
+        target: 73%
         threshold: 1%
     patch:
       default:

--- a/imports/api/Changes.ts
+++ b/imports/api/Changes.ts
@@ -1,0 +1,6 @@
+export type Changes<T> = {
+	$set?: Partial<T>;
+	$unset?: {
+		[K in keyof T]?: boolean;
+	};
+};

--- a/imports/api/_dev/populate/eids.ts
+++ b/imports/api/_dev/populate/eids.ts
@@ -1,0 +1,137 @@
+import {faker} from '@faker-js/faker';
+
+import format from 'date-fns/format';
+
+import {makeTemplate} from '../../../_test/fixtures';
+import {randomPNGBase64} from '../../../_test/png';
+
+const DATE_FORMAT = 'yyyyMMdd';
+const AGE_MAX = 130;
+
+export const newEidData = makeTemplate({
+	xml: {
+		// eslint-disable-next-line unicorn/text-encoding-identifier-case
+		encoding: () => 'UTF-8',
+		version: () => '1.0',
+	},
+	eid: {
+		graphpersoversion: () => faker.string.numeric(2),
+		version: () => faker.string.numeric(2),
+	},
+	card: {
+		carddata_appl_version: () => faker.string.numeric(2),
+		cardnumber: () => faker.string.numeric(12),
+		chipnumber: () => faker.string.alphanumeric(32),
+		documenttype: () => 'belgian_citizen',
+		validitydatebegin: () => format(faker.date.past({years: 30}), DATE_FORMAT),
+		validitydateend: () => format(faker.date.past({years: 30}), DATE_FORMAT),
+		deliverymunicipality: () => faker.location.county(),
+	},
+	certificates: {
+		authentication: () => faker.string.uuid(),
+		citizenca: () => faker.string.uuid(),
+		root: () => faker.string.uuid(),
+		rrn: () => faker.string.uuid(),
+		signing: () => faker.string.uuid(),
+	},
+	identity: {
+		nationality: () => faker.location.country(),
+		nationalnumber: () => faker.string.uuid(),
+		dateofbirth: () => format(faker.date.past({years: AGE_MAX}), DATE_FORMAT),
+		placeofbirth: () => faker.location.city(),
+		gender: () => faker.helpers.arrayElement(['male', 'female', undefined]),
+		specialstatus: () => faker.word.adjective(),
+		name: () => faker.person.lastName(),
+		firstname: () => faker.person.firstName(),
+		middlenames: () => faker.person.middleName(),
+		photo: () => undefined,
+	},
+	address: {
+		municipality: () => faker.location.city(),
+		streetandnumber: () => faker.location.streetAddress(),
+		zip: () => faker.location.zipCode(),
+	},
+});
+
+export const exampleEidXML = (options?: {
+	nationalnumber?: string;
+	dateofbirth?: string;
+	name?: string;
+	firstname?: string;
+	middlenames?: string;
+	nationality?: string;
+	placeofbirth?: string;
+	gender?: 'male' | 'female';
+	photo?: string;
+	streetandnumber?: string;
+	zip?: string;
+	municipality?: string;
+}) => {
+	const {
+		nationalnumber,
+		dateofbirth,
+		name,
+		firstname,
+		middlenames,
+		nationality,
+		placeofbirth,
+		gender,
+		photo,
+		streetandnumber,
+		zip,
+		municipality,
+	} = {
+		nationalnumber: '70010112345',
+		dateofbirth: '19700101',
+		name: 'Name',
+		firstname: 'First Name',
+		middlenames: 'M',
+		nationality: 'Belge',
+		placeofbirth: 'Bruxelles',
+		gender: 'female',
+		photo: randomPNGBase64(),
+		streetandnumber: 'Rue de la montagne 58 ',
+		zip: '1000',
+		municipality: 'Bruxelles',
+		...options,
+	};
+	// TODO: Generalizes and escape values.
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<eid version="4.3" graphpersoversion="00">
+	<identity
+	  nationalnumber="${nationalnumber}"
+	  dateofbirth="${dateofbirth}"
+	  gender="${gender}"
+	  specialstatus="NO_STATUS"
+	>
+		<name>${name}</name>
+		<firstname>${firstname}</firstname>
+		<middlenames>${middlenames}</middlenames>
+		<nationality>${nationality}</nationality>
+		<placeofbirth>${placeofbirth}</placeofbirth>
+		<photo>${photo}</photo>
+	</identity>
+	<card
+		documenttype="belgian_citizen"
+		carddata_appl_version="17"
+		cardnumber="012345678901"
+		chipnumber="0123456789ABCDEF0123456789ABCDEF"
+		validitydatebegin="20200101"
+		validitydateend="20300101"
+	>
+		<deliverymunicipality>Bruxelles</deliverymunicipality>
+	</card>
+	<address>
+		<streetandnumber>${streetandnumber}</streetandnumber>
+		<zip>${zip}</zip>
+		<municipality>${municipality}</municipality>
+	</address>
+	<certificates>
+		<root>ROOT</root>
+		<citizenca>CITIZENCA</citizenca>
+		<authentication>AUTHENTICATION</authentication>
+		<signing>SIGNING</signing>
+		<rrn>RRN</rrn>
+	</certificates>
+</eid>`;
+};

--- a/imports/api/collection/all.ts
+++ b/imports/api/collection/all.ts
@@ -1,6 +1,7 @@
 import type Collection from '../Collection';
 
 import {Settings} from './settings';
+import {Changes} from './changes';
 import {Eids} from './eids';
 import {Patients} from './patients';
 import {PatientsSearchIndex} from './patients/search';
@@ -17,6 +18,7 @@ import {Availability} from './availability';
 
 const collections: Array<Collection<any>> = [
 	Settings,
+	Changes,
 	Eids,
 	Patients,
 	PatientsSearchIndex,

--- a/imports/api/collection/all.ts
+++ b/imports/api/collection/all.ts
@@ -1,6 +1,7 @@
 import type Collection from '../Collection';
 
 import {Settings} from './settings';
+import {Eids} from './eids';
 import {Patients} from './patients';
 import {PatientsSearchIndex} from './patients/search';
 import {Drugs} from './drugs';
@@ -16,6 +17,7 @@ import {Availability} from './availability';
 
 const collections: Array<Collection<any>> = [
 	Settings,
+	Eids,
 	Patients,
 	PatientsSearchIndex,
 	Drugs,

--- a/imports/api/collection/changes.ts
+++ b/imports/api/collection/changes.ts
@@ -1,0 +1,53 @@
+import schema from '../../lib/schema';
+import {document} from '../Document';
+
+import define from './define';
+
+const changeDocument = schema.object({
+	_id: schema.string(),
+	owner: schema.string(),
+	when: schema.date(),
+	who: schema.object({
+		type: schema.literal('user'),
+		_id: schema.string(),
+	}),
+	why: schema.object({
+		method: schema.string(),
+		source: schema.union([
+			schema.object({
+				type: schema.literal('manual'),
+			}),
+			schema.object({
+				type: schema.literal('entity'),
+				collection: schema.string(),
+				_id: schema.string(),
+			}),
+		]),
+	}),
+	what: schema.object({
+		type: schema.union([schema.literal('patient'), schema.never()]),
+		_id: schema.string(),
+	}),
+	operation: schema.union([
+		schema.object({
+			type: schema.literal('update'),
+			$set: document.optional(),
+			$unset: schema.record(schema.string(), schema.boolean()).optional(),
+		}),
+		schema.object({
+			type: schema.literal('create'),
+			$set: document.optional(),
+		}),
+		schema.object({
+			type: schema.literal('read'),
+		}),
+		schema.object({
+			type: schema.literal('delete'),
+		}),
+	]),
+});
+
+export type ChangeDocument = schema.infer<typeof changeDocument>;
+
+const collection = 'changes';
+export const Changes = define<ChangeDocument>(collection);

--- a/imports/api/collection/eids.ts
+++ b/imports/api/collection/eids.ts
@@ -1,0 +1,75 @@
+import schema from '../../lib/schema';
+
+import define from './define';
+
+export const eidFields = schema.object({
+	xml: schema
+		.object({
+			encoding: schema.string(),
+			version: schema.string(),
+		})
+		.partial(),
+	eid: schema
+		.object({
+			graphpersoversion: schema.string(),
+			version: schema.string(),
+		})
+		.partial(),
+	card: schema
+		.object({
+			carddata_appl_version: schema.string(),
+			cardnumber: schema.string(),
+			chipnumber: schema.string(),
+			documenttype: schema.string(),
+			validitydatebegin: schema.string(),
+			validitydateend: schema.string(),
+			deliverymunicipality: schema.string(),
+		})
+		.partial(),
+	certificates: schema
+		.object({
+			authentication: schema.string(),
+			citizenca: schema.string(),
+			root: schema.string(),
+			rrn: schema.string(),
+			signing: schema.string(),
+		})
+		.partial(),
+	identity: schema
+		.object({
+			nationality: schema.string(),
+			nationalnumber: schema.string(),
+			dateofbirth: schema.string(),
+			placeofbirth: schema.string(),
+			gender: schema.string(),
+			specialstatus: schema.string(),
+			name: schema.string(),
+			firstname: schema.string(),
+			middlenames: schema.string(),
+			photo: schema.string(),
+		})
+		.partial(),
+	address: schema
+		.object({
+			municipality: schema.string(),
+			streetandnumber: schema.string(),
+			zip: schema.string(),
+		})
+		.partial(),
+});
+
+export type EidFields = schema.infer<typeof eidFields>;
+
+const eidMetadata = schema.object({
+	_id: schema.string(),
+	owner: schema.string(),
+	createdAt: schema.date(),
+});
+
+export type EidMetadata = schema.infer<typeof eidMetadata>;
+
+export const eidDocument = eidFields.merge(eidMetadata);
+export type EidDocument = schema.infer<typeof eidDocument>;
+
+const collection = 'eids';
+export const Eids = define<EidDocument>(collection);

--- a/imports/api/collection/eids.ts
+++ b/imports/api/collection/eids.ts
@@ -64,6 +64,7 @@ const eidMetadata = schema.object({
 	_id: schema.string(),
 	owner: schema.string(),
 	createdAt: schema.date(),
+	lastUsedAt: schema.date(),
 });
 
 export type EidMetadata = schema.infer<typeof eidMetadata>;

--- a/imports/api/eidParseXML.ts
+++ b/imports/api/eidParseXML.ts
@@ -1,28 +1,120 @@
 import {xml2json} from 'xml-js';
 
-import {type PatientIdFields} from './collection/patients';
+import schema from '../lib/schema';
 
-const eidParseXML = (xmlString: string): PatientIdFields => {
+import {type EidFields} from './collection/eids';
+
+const text = schema.object({
+	_text: schema.string().optional(),
+});
+
+export const eidXml = schema.object({
+	_declaration: schema.object({
+		_attributes: schema
+			.object({
+				encoding: schema.string(),
+				version: schema.string(),
+			})
+			.partial(),
+	}),
+	eid: schema.object({
+		_attributes: schema
+			.object({
+				graphpersoversion: schema.string(),
+				version: schema.string(),
+			})
+			.partial(),
+		address: schema
+			.object({
+				municipality: text.optional(),
+				streetandnumber: text.optional(),
+				zip: text.optional(),
+			})
+			.optional(),
+		card: schema
+			.object({
+				_attributes: schema
+					.object({
+						carddata_appl_version: schema.string(),
+						cardnumber: schema.string(),
+						chipnumber: schema.string(),
+						documenttype: schema.string(),
+						validitydatebegin: schema.string(),
+						validitydateend: schema.string(),
+					})
+					.partial(),
+				deliverymunicipality: text.optional(),
+			})
+			.optional(),
+		certificates: schema
+			.object({
+				authentication: text.optional(),
+				citizenca: text.optional(),
+				root: text.optional(),
+				rrn: text.optional(),
+				signing: text.optional(),
+			})
+			.optional(),
+		identity: schema
+			.object({
+				_attributes: schema
+					.object({
+						dateofbirth: schema.string(),
+						gender: schema.string(),
+						nationalnumber: schema.string(),
+						specialstatus: schema.string(),
+					})
+					.partial(),
+				firstname: text.optional(),
+				middlenames: text.optional(),
+				name: text.optional(),
+				nationality: text.optional(),
+				photo: text.optional(),
+				placeofbirth: text.optional(),
+			})
+			.optional(),
+	}),
+});
+
+const eidParseXML = (xmlString: string): EidFields => {
 	// TODO validate using xsd
 	const jsonString = xml2json(xmlString, {compact: true, spaces: 4});
 	const json = JSON.parse(jsonString);
 	console.debug('eidXMLToJSON', {json});
 
-	const {address, identity} = json.eid;
-	const attributes = identity._attributes;
-	const d = attributes.dateofbirth;
+	const {
+		_declaration: {_attributes: xml},
+		eid: {_attributes: eid, address, card, certificates, identity},
+	} = eidXml.parse(json);
 
 	return {
-		niss: attributes.nationalnumber,
-		firstname: identity.firstname._text,
-		lastname: identity.name._text,
-		photo: identity.photo._text,
-		birthdate: `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`,
-		sex: attributes.gender,
-
-		municipality: address.municipality._text,
-		streetandnumber: address.streetandnumber._text,
-		zip: address.zip._text,
+		xml,
+		eid,
+		address: {
+			municipality: address?.municipality?._text,
+			streetandnumber: address?.streetandnumber?._text,
+			zip: address?.zip?._text,
+		},
+		card: {
+			...card?._attributes,
+			deliverymunicipality: card?.deliverymunicipality?._text,
+		},
+		certificates: {
+			authentication: certificates?.authentication?._text,
+			citizenca: certificates?.citizenca?._text,
+			root: certificates?.root?._text,
+			rrn: certificates?.rrn?._text,
+			signing: certificates?.signing?._text,
+		},
+		identity: {
+			...identity?._attributes,
+			nationality: identity?.nationality?._text,
+			firstname: identity?.firstname?._text,
+			middlenames: identity?.middlenames?._text,
+			name: identity?.name?._text,
+			photo: identity?.photo?._text,
+			placeofbirth: identity?.placeofbirth?._text,
+		},
 	};
 };
 

--- a/imports/api/endpoint/patients/insert.ts
+++ b/imports/api/endpoint/patients/insert.ts
@@ -1,7 +1,12 @@
 import {AuthenticationLoggedIn} from '../../Authentication';
 
 import schema from '../../../lib/schema';
-import {patientFields, Patients} from '../../collection/patients';
+import {
+	type PatientFields,
+	patientFields,
+	Patients,
+} from '../../collection/patients';
+import {Changes} from '../../collection/changes';
 import {computeUpdate, patients} from '../../patients';
 import type TransactionDriver from '../../transaction/TransactionDriver';
 
@@ -9,29 +14,59 @@ import define from '../define';
 
 const {sanitize, updateIndex, updateTags} = patients;
 
+export const _insert = async (
+	db: TransactionDriver,
+	owner: string,
+	fields: PatientFields,
+) => {
+	const changes = sanitize(fields);
+	const {newState} = await computeUpdate(db, owner, undefined, changes);
+
+	const patient = {
+		...newState,
+		createdAt: new Date(),
+		owner,
+	};
+	await updateTags(db, owner, patient);
+	const {insertedId: patientId} = await db.insertOne(Patients, patient);
+	await updateIndex(db, owner, patientId, patient);
+	return {
+		...patient,
+		_id: patientId,
+	};
+};
+
 export default define({
 	name: '/api/patients/insert',
 	authentication: AuthenticationLoggedIn,
 	schema: schema.tuple([patientFields.strict()]),
-	async transaction(db: TransactionDriver, patient) {
+	async transaction(db: TransactionDriver, fields) {
 		const owner = this.userId;
-		const changes = sanitize(patient);
-		const {newState: fields} = await computeUpdate(
-			db,
-			owner,
-			undefined,
-			changes,
-		);
 
-		await updateTags(db, owner, fields);
+		const {_id: patientId, ...$set} = await _insert(db, owner, fields);
 
-		const {insertedId: patientId} = await db.insertOne(Patients, {
-			...fields,
-			createdAt: new Date(),
+		await db.insertOne(Changes, {
 			owner,
+			when: $set.createdAt,
+			who: {
+				type: 'user',
+				_id: owner,
+			},
+			why: {
+				method: 'insert',
+				source: {
+					type: 'manual',
+				},
+			},
+			what: {
+				type: 'patient',
+				_id: patientId,
+			},
+			operation: {
+				type: 'create',
+				$set,
+			},
 		});
-
-		await updateIndex(db, owner, patientId, fields);
 
 		return patientId;
 	},

--- a/imports/api/endpoint/patients/insertFromEid.app-tests.ts
+++ b/imports/api/endpoint/patients/insertFromEid.app-tests.ts
@@ -1,0 +1,31 @@
+import {assert} from 'chai';
+
+import {randomUserId, server} from '../../../_test/fixtures';
+
+import {Eids} from '../../collection/eids';
+
+import {newEidData} from '../../_dev/populate/eids';
+import invoke from '../invoke';
+
+import insertFromEid from './insertFromEid';
+
+server(__filename, () => {
+	it('does not create duplicate eid entries', async () => {
+		const userId = randomUserId();
+
+		const eid = newEidData();
+
+		await invoke(insertFromEid, {userId}, [eid]);
+		const oldEntry = await Eids.findOneAsync({owner: userId});
+		assert.isDefined(oldEntry);
+
+		await invoke(insertFromEid, {userId}, [eid]);
+		const entries = await Eids.find({owner: userId}).fetchAsync();
+
+		assert.strictEqual(entries.length, 1);
+
+		const {createdAt, lastUsedAt} = entries[0]!;
+		assert.strictEqual(createdAt.valueOf(), oldEntry.createdAt.valueOf());
+		assert.isAbove(lastUsedAt.valueOf(), oldEntry.lastUsedAt.valueOf());
+	});
+});

--- a/imports/api/endpoint/patients/insertFromEid.tests.ts
+++ b/imports/api/endpoint/patients/insertFromEid.tests.ts
@@ -2,6 +2,7 @@ import {assert} from 'chai';
 
 import {randomUserId, server, throws} from '../../../_test/fixtures';
 
+import {Eids} from '../../collection/eids';
 import {Patients} from '../../collection/patients';
 import {Allergies} from '../../collection/allergies';
 import {Doctors} from '../../collection/doctors';
@@ -11,6 +12,8 @@ import {newEidData} from '../../_dev/populate/eids';
 import invoke from '../invoke';
 
 import {normalizedName, patientFieldsFromEid} from '../../patients';
+
+import removeUndefined from '../../../lib/object/removeUndefined';
 
 import insertFromEid from './insertFromEid';
 
@@ -64,5 +67,32 @@ server(__filename, () => {
 		assert.sameDeepMembers(await Allergies.find().fetchAsync(), []);
 		assert.sameDeepMembers(await Doctors.find().fetchAsync(), []);
 		assert.sameDeepMembers(await Insurances.find().fetchAsync(), []);
+	});
+
+	it('creates an eid entry', async () => {
+		const userId = randomUserId();
+
+		const eid = newEidData();
+
+		await invoke(insertFromEid, {userId}, [eid]);
+
+		const entries = await Eids.find({owner: userId}).fetchAsync();
+
+		assert.strictEqual(entries.length, 1);
+
+		const {_id, createdAt, owner, ...rest} = entries[0]!;
+
+		assert.strictEqual(owner, userId);
+		assert.isAtMost(createdAt.valueOf(), Date.now());
+
+		assert.deepEqual(
+			rest,
+			Object.fromEntries(
+				Object.entries(eid).map(([key, value]) => [
+					key,
+					removeUndefined(value as {}),
+				]),
+			),
+		);
 	});
 });

--- a/imports/api/endpoint/patients/insertFromEid.tests.ts
+++ b/imports/api/endpoint/patients/insertFromEid.tests.ts
@@ -80,10 +80,11 @@ server(__filename, () => {
 
 		assert.strictEqual(entries.length, 1);
 
-		const {_id, createdAt, owner, ...rest} = entries[0]!;
+		const {_id, createdAt, lastUsedAt, owner, ...rest} = entries[0]!;
 
 		assert.strictEqual(owner, userId);
 		assert.isAtMost(createdAt.valueOf(), Date.now());
+		assert.strictEqual(lastUsedAt.valueOf(), createdAt.valueOf());
 
 		assert.deepEqual(
 			rest,

--- a/imports/api/endpoint/patients/insertFromEid.tests.ts
+++ b/imports/api/endpoint/patients/insertFromEid.tests.ts
@@ -1,0 +1,68 @@
+import {assert} from 'chai';
+
+import {randomUserId, server, throws} from '../../../_test/fixtures';
+
+import {Patients} from '../../collection/patients';
+import {Allergies} from '../../collection/allergies';
+import {Doctors} from '../../collection/doctors';
+import {Insurances} from '../../collection/insurances';
+
+import {newEidData} from '../../_dev/populate/eids';
+import invoke from '../invoke';
+
+import {normalizedName, patientFieldsFromEid} from '../../patients';
+
+import insertFromEid from './insertFromEid';
+
+server(__filename, () => {
+	it('cannot create a patient when not logged in', async () => {
+		return throws(
+			async () =>
+				invoke(
+					insertFromEid,
+					// @ts-expect-error Type-checking is working as expected.
+					{userId: undefined},
+					[newEidData()],
+				),
+			/not-authorized/,
+		);
+	});
+
+	it('can create a patient when logged in', async () => {
+		const userId = randomUserId();
+
+		const eid = newEidData();
+
+		const patientId = await invoke(insertFromEid, {userId}, [eid]);
+
+		const patients = await Patients.find({owner: userId}).fetchAsync();
+
+		assert.strictEqual(patients.length, 1);
+
+		const expectedPatientFields = patientFieldsFromEid(eid);
+		const expectedComputedFields = {
+			normalizedName: normalizedName(
+				expectedPatientFields.firstname,
+				expectedPatientFields.lastname,
+			),
+		};
+
+		const expected = {
+			...expectedPatientFields,
+			...expectedComputedFields,
+		};
+		const {_id, createdAt, owner, ...actual} = patients[0]!;
+
+		assert.strictEqual(patientId, _id);
+
+		assert.strictEqual(owner, userId);
+
+		assert.deepEqual(actual, expected);
+
+		assert.isAtMost(createdAt.valueOf(), Date.now());
+
+		assert.sameDeepMembers(await Allergies.find().fetchAsync(), []);
+		assert.sameDeepMembers(await Doctors.find().fetchAsync(), []);
+		assert.sameDeepMembers(await Insurances.find().fetchAsync(), []);
+	});
+});

--- a/imports/api/endpoint/patients/insertFromEid.ts
+++ b/imports/api/endpoint/patients/insertFromEid.ts
@@ -17,11 +17,26 @@ export default define({
 	async transaction(db: TransactionDriver, eid) {
 		const owner = this.userId;
 
-		await db.insertOne(Eids, {
-			...eid,
-			createdAt: new Date(),
-			owner,
-		});
+		const lastUsedAt = new Date();
+
+		await db.updateOne(
+			Eids,
+			{
+				owner,
+				...eid,
+			},
+			{
+				$set: {
+					lastUsedAt,
+				},
+				$setOnInsert: {
+					createdAt: lastUsedAt,
+				},
+			},
+			{
+				upsert: true,
+			},
+		);
 
 		const patient = patientFieldsFromEid(eid);
 

--- a/imports/api/endpoint/patients/insertFromEid.ts
+++ b/imports/api/endpoint/patients/insertFromEid.ts
@@ -1,0 +1,33 @@
+import {AuthenticationLoggedIn} from '../../Authentication';
+
+import schema from '../../../lib/schema';
+import {eidFields, Eids} from '../../collection/eids';
+import {patientFieldsFromEid} from '../../patients';
+import type TransactionDriver from '../../transaction/TransactionDriver';
+
+import define from '../define';
+import compose from '../compose';
+
+import insert from './insert';
+
+export default define({
+	name: '/api/patients/insertFromEid',
+	authentication: AuthenticationLoggedIn,
+	schema: schema.tuple([eidFields.strict()]),
+	async transaction(db: TransactionDriver, eid) {
+		const owner = this.userId;
+
+		await db.insertOne(Eids, {
+			...eid,
+			createdAt: new Date(),
+			owner,
+		});
+
+		const patient = patientFieldsFromEid(eid);
+
+		return compose(db, insert, this, [patient]);
+	},
+	simulate(_patient) {
+		return undefined;
+	},
+});

--- a/imports/api/endpoint/patients/update.ts
+++ b/imports/api/endpoint/patients/update.ts
@@ -1,44 +1,101 @@
 import {AuthenticationLoggedIn} from '../../Authentication';
 import schema from '../../../lib/schema';
 
-import {patientUpdate, Patients} from '../../collection/patients';
+import {
+	patientUpdate,
+	Patients,
+	type PatientUpdate,
+} from '../../collection/patients';
 import {computeUpdate, patients} from '../../patients';
 import type TransactionDriver from '../../transaction/TransactionDriver';
 
 import define from '../define';
 import EndpointError from '../EndpointError';
+import {Changes} from '../../collection/changes';
 
 const {sanitize, updateIndex, updateTags} = patients;
+
+export const _update = async (
+	db: TransactionDriver,
+	owner: string,
+	patientId: string,
+	documentUpdate: PatientUpdate,
+) => {
+	const patient = await db.findOne(Patients, {
+		_id: patientId,
+		owner,
+	});
+
+	if (patient === null) {
+		throw new EndpointError('not-found');
+	}
+
+	const changes = sanitize(documentUpdate);
+	const {$set, $unset, newState} = await computeUpdate(
+		db,
+		owner,
+		patient,
+		changes,
+	);
+
+	if ($set !== undefined) await updateTags(db, owner, $set);
+
+	await updateIndex(db, owner, patientId, newState, $unset);
+
+	const result = await db.updateOne(
+		Patients,
+		{_id: patientId, owner},
+		{$set, $unset},
+	);
+
+	return {
+		result,
+		$set,
+		$unset,
+	};
+};
 
 export default define({
 	name: '/api/patients/update',
 	authentication: AuthenticationLoggedIn,
 	schema: schema.tuple([schema.string(), patientUpdate.strict()]),
-	async transaction(db: TransactionDriver, patientId, newfields) {
+	async transaction(db: TransactionDriver, patientId, documentUpdate) {
 		const owner = this.userId;
 
-		const patient = await db.findOne(Patients, {
-			_id: patientId,
-			owner,
-		});
-
-		if (patient === null) {
-			throw new EndpointError('not-found');
-		}
-
-		const changes = sanitize(newfields);
-		const {$set, $unset, newState} = await computeUpdate(
+		const {result, $set, $unset} = await _update(
 			db,
 			owner,
-			patient,
-			changes,
+			patientId,
+			documentUpdate,
 		);
 
-		if ($set !== undefined) await updateTags(db, owner, $set);
+		if (result.modifiedCount >= 1) {
+			await db.insertOne(Changes, {
+				owner,
+				when: new Date(),
+				who: {
+					type: 'user',
+					_id: owner,
+				},
+				why: {
+					method: 'update',
+					source: {
+						type: 'manual',
+					},
+				},
+				what: {
+					type: 'patient',
+					_id: patientId,
+				},
+				operation: {
+					type: 'update',
+					$set,
+					$unset,
+				},
+			});
+		}
 
-		await updateIndex(db, owner, patientId, newState, $unset);
-
-		return db.updateOne(Patients, {_id: patientId, owner}, {$set, $unset});
+		return result;
 	},
 	simulate(_patientId, _newfields) {
 		return undefined;

--- a/imports/api/endpoint/patients/updateFromEid.app-tests.ts
+++ b/imports/api/endpoint/patients/updateFromEid.app-tests.ts
@@ -1,0 +1,35 @@
+import {assert} from 'chai';
+
+import {randomUserId, server} from '../../../_test/fixtures';
+
+import {newPatient} from '../../_dev/populate/patients';
+import invoke from '../invoke';
+
+import {newEidData} from '../../_dev/populate/eids';
+
+import {Eids} from '../../collection/eids';
+
+import updateFromEid from './updateFromEid';
+
+server(__filename, () => {
+	it('does not create duplicate eid entries', async () => {
+		const userId = randomUserId();
+
+		const eid = newEidData();
+
+		const patientId = await newPatient({userId});
+
+		await invoke(updateFromEid, {userId}, [patientId, eid]);
+		const oldEntry = await Eids.findOneAsync({owner: userId});
+		assert.isDefined(oldEntry);
+
+		await invoke(updateFromEid, {userId}, [patientId, eid]);
+		const entries = await Eids.find({owner: userId}).fetchAsync();
+
+		assert.strictEqual(entries.length, 1);
+
+		const {createdAt, lastUsedAt} = entries[0]!;
+		assert.strictEqual(createdAt.valueOf(), oldEntry.createdAt.valueOf());
+		assert.isAbove(lastUsedAt.valueOf(), oldEntry.lastUsedAt.valueOf());
+	});
+});

--- a/imports/api/endpoint/patients/updateFromEid.tests.ts
+++ b/imports/api/endpoint/patients/updateFromEid.tests.ts
@@ -162,10 +162,11 @@ server(__filename, () => {
 
 		assert.strictEqual(entries.length, 1);
 
-		const {_id, createdAt, owner, ...rest} = entries[0]!;
+		const {_id, createdAt, lastUsedAt, owner, ...rest} = entries[0]!;
 
 		assert.strictEqual(owner, userId);
 		assert.isAtMost(createdAt.valueOf(), Date.now());
+		assert.strictEqual(lastUsedAt.valueOf(), createdAt.valueOf());
 
 		assert.deepEqual(
 			rest,

--- a/imports/api/endpoint/patients/updateFromEid.tests.ts
+++ b/imports/api/endpoint/patients/updateFromEid.tests.ts
@@ -1,0 +1,148 @@
+import {assert} from 'chai';
+
+import {randomUserId, server, throws} from '../../../_test/fixtures';
+
+import {Patients} from '../../collection/patients';
+import {Allergies} from '../../collection/allergies';
+import {Doctors} from '../../collection/doctors';
+import {Insurances} from '../../collection/insurances';
+
+import {newPatient} from '../../_dev/populate/patients';
+import invoke from '../invoke';
+
+import {newEidData} from '../../_dev/populate/eids';
+import {normalizedName, patientFieldsFromEid} from '../../patients';
+
+import updateFromEid from './updateFromEid';
+
+server(__filename, () => {
+	it('cannot update a patient when not logged in', async () => {
+		const userId = randomUserId();
+		const patientId = await newPatient({userId});
+		const eidInfo = newEidData();
+		return throws(
+			async () =>
+				invoke(
+					updateFromEid,
+					// @ts-expect-error Type-checking is working as expected.
+					{userId: undefined},
+					[patientId, eidInfo],
+				),
+			/not-authorized/,
+		);
+	});
+
+	it("cannot update another user's patient", async () => {
+		const userId = randomUserId();
+		const patientId = await newPatient({userId});
+		const eidInfo = newEidData();
+		return throws(
+			async () =>
+				invoke(updateFromEid, {userId: `${userId}x`}, [patientId, eidInfo]),
+			/not-found/,
+		);
+	});
+
+	it('cannot update a non-existing patient', async () => {
+		const userId = randomUserId();
+		const patientId = await newPatient({userId});
+		const eidInfo = newEidData();
+		return throws(
+			async () => invoke(updateFromEid, {userId}, [`${patientId}x`, eidInfo]),
+			/not-found/,
+		);
+	});
+
+	it('can update a patient when logged in', async () => {
+		const userId = randomUserId();
+
+		const eid = newEidData();
+
+		const patientId = await newPatient({userId});
+
+		const patientsBefore = await Patients.find({owner: userId}).fetchAsync();
+
+		assert.strictEqual(patientsBefore.length, 1);
+
+		const {
+			photo,
+			sex,
+			about,
+			antecedents,
+			noshow,
+			allergies,
+			insurances,
+			doctors,
+			ongoing,
+			phone,
+		} = patientsBefore[0]!;
+
+		await invoke(updateFromEid, {userId}, [patientId, eid]);
+
+		const patients = await Patients.find({owner: userId}).fetchAsync();
+
+		assert.strictEqual(patients.length, 1);
+
+		const expectedPreviousFieldsIfAbsentInEid = {
+			sex,
+			photo,
+		};
+
+		const expectedChangedFields = patientFieldsFromEid(eid);
+		const expectedComputedFields = {
+			normalizedName: normalizedName(
+				expectedChangedFields.firstname,
+				expectedChangedFields.lastname,
+			),
+		};
+
+		const expectedUnchangedFields = {
+			about,
+			antecedents,
+			allergies,
+			insurances,
+			doctors,
+			noshow,
+			ongoing,
+			phone,
+		};
+
+		const expected = {
+			...expectedPreviousFieldsIfAbsentInEid,
+			...expectedChangedFields,
+			...expectedComputedFields,
+			...expectedUnchangedFields,
+		};
+		const {_id, createdAt, owner, ...actual} = patients[0]!;
+
+		assert.strictEqual(patientId, _id);
+
+		assert.strictEqual(owner, userId);
+
+		assert.deepEqual(actual, expected);
+
+		assert.isAtMost(createdAt.valueOf(), Date.now());
+
+		assert.includeDeepMembers(
+			await Allergies.find().mapAsync(({displayName, name}) => ({
+				displayName,
+				name,
+			})),
+			allergies!.map(({displayName, name}) => ({displayName, name})),
+		);
+		assert.includeDeepMembers(
+			await Doctors.find().mapAsync(({displayName, name}) => ({
+				displayName,
+				name,
+			})),
+			doctors!.map(({displayName, name}) => ({displayName, name})),
+		);
+		assert.includeDeepMembers(
+			await Insurances.find().mapAsync(({displayName, name}) => ({
+				displayName,
+				name,
+			})),
+			insurances!.map(({displayName, name}) => ({displayName, name})),
+		);
+	});
+});

--- a/imports/api/endpoint/patients/updateFromEid.tests.ts
+++ b/imports/api/endpoint/patients/updateFromEid.tests.ts
@@ -16,6 +16,8 @@ import {normalizedName, patientFieldsFromEid} from '../../patients';
 import {Eids} from '../../collection/eids';
 import removeUndefined from '../../../lib/object/removeUndefined';
 
+import {Changes} from '../../collection/changes';
+
 import updateFromEid from './updateFromEid';
 
 server(__filename, () => {
@@ -177,5 +179,74 @@ server(__filename, () => {
 				]),
 			),
 		);
+	});
+
+	it('does not create duplicate eid entries', async () => {
+		const userId = randomUserId();
+
+		const eid = newEidData();
+
+		const patientId = await newPatient({userId});
+
+		await invoke(updateFromEid, {userId}, [patientId, eid]);
+		const oldEntry = await Eids.findOneAsync({owner: userId});
+		assert.isDefined(oldEntry);
+
+		await invoke(updateFromEid, {userId}, [patientId, eid]);
+		const entries = await Eids.find({owner: userId}).fetchAsync();
+
+		assert.strictEqual(entries.length, 1);
+
+		const {createdAt, lastUsedAt} = entries[0]!;
+		assert.strictEqual(createdAt.valueOf(), oldEntry.createdAt.valueOf());
+		assert.isAbove(lastUsedAt.valueOf(), oldEntry.lastUsedAt.valueOf());
+	});
+
+	it('creates associated Changes entries', async () => {
+		const userId = randomUserId();
+
+		const eid = newEidData();
+
+		const patientId = await newPatient({userId}, {firstname: 'Alice'});
+
+		await invoke(updateFromEid, {userId}, [patientId, eid]);
+
+		const {_id: eidId} = (await Eids.findOneAsync({owner: userId}))!;
+
+		const changes = await Changes.find({
+			owner: userId,
+			'operation.type': 'update',
+		}).fetchAsync();
+
+		assert.lengthOf(changes, 1);
+
+		const {operation, what, who, when, why} = changes[0]!;
+
+		assert.deepNestedInclude(operation, {
+			'$set.firstname': eid.identity.firstname,
+			$unset: {},
+			type: 'update',
+		});
+
+		assert.deepNestedInclude(what, {
+			_id: patientId,
+			type: 'patient',
+		});
+
+		assert.deepNestedInclude(who, {
+			_id: userId,
+			type: 'user',
+		});
+
+		assert.typeOf(when, 'Date');
+
+		assert.deepNestedInclude(why, {
+			method: 'updateFromEid',
+			source: {
+				type: 'entity',
+				collection: 'eid',
+				_id: eidId,
+			},
+		});
 	});
 });

--- a/imports/api/endpoint/patients/updateFromEid.ts
+++ b/imports/api/endpoint/patients/updateFromEid.ts
@@ -1,0 +1,33 @@
+import {AuthenticationLoggedIn} from '../../Authentication';
+
+import schema from '../../../lib/schema';
+import {eidFields, Eids} from '../../collection/eids';
+import {patientFieldsFromEid} from '../../patients';
+import type TransactionDriver from '../../transaction/TransactionDriver';
+
+import define from '../define';
+import compose from '../compose';
+
+import update from './update';
+
+export default define({
+	name: '/api/patients/updateFromEid',
+	authentication: AuthenticationLoggedIn,
+	schema: schema.tuple([schema.string(), eidFields.strict()]),
+	async transaction(db: TransactionDriver, patientId, eid) {
+		const owner = this.userId;
+
+		await db.insertOne(Eids, {
+			...eid,
+			createdAt: new Date(),
+			owner,
+		});
+
+		const changes = patientFieldsFromEid(eid);
+
+		return compose(db, update, this, [patientId, changes]);
+	},
+	simulate(_patient) {
+		return undefined;
+	},
+});

--- a/imports/api/endpoint/patients/updateFromEid.ts
+++ b/imports/api/endpoint/patients/updateFromEid.ts
@@ -17,11 +17,26 @@ export default define({
 	async transaction(db: TransactionDriver, patientId, eid) {
 		const owner = this.userId;
 
-		await db.insertOne(Eids, {
-			...eid,
-			createdAt: new Date(),
-			owner,
-		});
+		const lastUsedAt = new Date();
+
+		await db.updateOne(
+			Eids,
+			{
+				owner,
+				...eid,
+			},
+			{
+				$set: {
+					lastUsedAt,
+				},
+				$setOnInsert: {
+					createdAt: lastUsedAt,
+				},
+			},
+			{
+				upsert: true,
+			},
+		);
 
 		const changes = patientFieldsFromEid(eid);
 

--- a/imports/api/patients.ts
+++ b/imports/api/patients.ts
@@ -81,7 +81,15 @@ const updateIndex = async (
 		birthdate,
 		deathdateModifiedAt,
 		sex,
-	}: PatientDocument,
+	}: Pick<
+		PatientDocument,
+		| 'niss'
+		| 'firstname'
+		| 'lastname'
+		| 'birthdate'
+		| 'deathdateModifiedAt'
+		| 'sex'
+	>,
 	$unset?: {},
 ) => {
 	const [firstnameWords, middlenameWords] = splitNames(firstname);

--- a/imports/api/patients.ts
+++ b/imports/api/patients.ts
@@ -8,6 +8,8 @@ import isValid from 'date-fns/isValid';
 
 import schema from '../lib/schema';
 
+import removeUndefined from '../lib/object/removeUndefined';
+
 import {
 	type PatientFields,
 	type PatientComputedFields,
@@ -17,6 +19,8 @@ import {
 	type PatientDocument,
 	type PatientTagFields,
 	patientSex,
+	patientIdFields,
+	type PatientIdFields,
 } from './collection/patients';
 
 import {PatientsSearchIndex} from './collection/patients/search';
@@ -48,6 +52,7 @@ import {
 	yieldResettableKey,
 } from './update';
 import {type DocumentUpdate} from './DocumentUpdate';
+import {type EidFields} from './collection/eids';
 
 const splitNames = (string: string) => {
 	const [firstname, ...middlenames] = names(string);
@@ -381,6 +386,28 @@ function createPatient(string: string) {
 		_id: '?',
 	};
 }
+
+export const patientFieldsFromEid = ({
+	address,
+	identity: {nationalnumber, gender, firstname, name, photo, dateofbirth},
+}: EidFields): PatientIdFields =>
+	removeUndefined(
+		patientIdFields.parse({
+			niss: nationalnumber,
+			firstname,
+			lastname: name,
+			photo,
+			birthdate:
+				dateofbirth === undefined
+					? undefined
+					: `${dateofbirth.slice(0, 4)}-${dateofbirth.slice(
+							4,
+							6,
+					  )}-${dateofbirth.slice(6, 8)}`,
+			sex: gender,
+			...address,
+		}),
+	);
 
 export const patients = {
 	updateIndex,

--- a/imports/api/patients/insertPatient.tsx
+++ b/imports/api/patients/insertPatient.tsx
@@ -17,13 +17,16 @@ const insertPatient = async (
 
 	const eidInfo = eidParseXML(xmlString);
 
-	return dialog<void>((resolve) => (
+	return dialog<void>((resolve, reject) => (
 		<EidCardDialog
 			open={false}
 			navigate={navigate}
 			eidInfo={eidInfo}
-			onClose={() => {
+			onConfirm={() => {
 				resolve();
+			}}
+			onCancel={() => {
+				reject(new Error('Closed eid dialog.'));
 			}}
 		/>
 	));

--- a/imports/api/update.ts
+++ b/imports/api/update.ts
@@ -12,6 +12,7 @@ import {
 	type RequiredKeys,
 } from './DocumentUpdate';
 import type TransactionDriver from './transaction/TransactionDriver';
+import {type Changes} from './Changes';
 
 const id = <T>(x: T): T => x;
 
@@ -48,13 +49,6 @@ export const yieldResettableKey = function* <T, K extends keyof T>(
 		type.nullable().optional().parse(fields[key]);
 		yield [key, transform(fields[key])];
 	}
-};
-
-type Changes<T> = {
-	$set?: Partial<T>;
-	$unset?: {
-		[K in keyof T]?: boolean;
-	};
 };
 
 export const simulateUpdate = <T extends {}>(
@@ -127,7 +121,7 @@ export const makeSanitize =
 	<T extends Document, U extends Document>(
 		sanitizeUpdate: SanitizeUpdate<T, U>,
 	) =>
-	(fields: DocumentUpdate<T>) => {
+	(fields: DocumentUpdate<T>): Required<Changes<U>> => {
 		const update = Array.from(sanitizeUpdate(fields));
 		return {
 			$set: Object.fromEntries(
@@ -137,7 +131,7 @@ export const makeSanitize =
 				update
 					.filter(([, value]) => value === undefined || value === null)
 					.map(([key]) => [key, true]),
-			),
+			) as {[K in keyof U]?: boolean},
 		};
 	};
 

--- a/imports/migrations/versions/v1.ts
+++ b/imports/migrations/versions/v1.ts
@@ -33,6 +33,7 @@ import {availability} from '../../api/availability';
 import {names} from '../../api/createTagCollection';
 import type TagDocument from '../../api/tags/TagDocument';
 import db from '../../backend/mongodb/db';
+import {Eids} from '../../api/collection/eids';
 
 export default async () => {
 	// Check that all ids are strings
@@ -312,6 +313,47 @@ export default async () => {
 	await createSimpleUniqueIndex(Doctors, 'name');
 	await createSimpleUniqueIndex(Allergies, 'name');
 	await createSimpleUniqueIndex(Books, 'name');
+
+	await Eids.rawCollection().createIndex(
+		{
+			owner: 1,
+			// NOTE: Those are the fields that are the most likely to change.
+			'card.cardnumber': 1,
+			'card.chipnumber': 1,
+			// NOTE: If the ones above match, usually the rest will match too.
+			'xml.encoding': 1,
+			'xml.version': 1,
+			'eid.graphpersoversion': 1,
+			'eid.version': 1,
+			'card.carddata_appl_version': 1,
+			'card.documenttype': 1,
+			'card.validitydatebegin': 1,
+			'card.validitydateend': 1,
+			'card.deliverymunicipality': 1,
+			'certificates.authentication': 1,
+			'certificates.citizenca': 1,
+			'certificates.root': 1,
+			'certificates.rrn': 1,
+			'certificates.signing': 1,
+			'identity.nationality': 1,
+			'identity.nationalnumber': 1,
+			'identity.dateofbirth': 1,
+			'identity.placeofbirth': 1,
+			'identity.gender': 1,
+			'identity.specialstatus': 1,
+			'identity.name': 1,
+			'identity.firstname': 1,
+			'identity.middlenames': 1,
+			'identity.photo': 1,
+			'address.municipality': 1,
+			'address.streetandnumber': 1,
+			'address.zip': 1,
+		},
+		{
+			unique: true,
+			background: true,
+		},
+	);
 
 	await Books.rawCollection().createIndex(
 		{

--- a/imports/ui/eid/EidCardDialog.tsx
+++ b/imports/ui/eid/EidCardDialog.tsx
@@ -6,14 +6,14 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 
-import {type PatientIdFields} from '../../api/collection/patients';
+import {type EidFields} from '../../api/collection/eids';
 
 import EidCardDialogStepSelection from './EidCardDialogStepSelection';
 import EidCardDialogStepPreviewSingle from './EidCardDialogStepPreviewSingle';
 
 type Props = {
 	readonly navigate: ReturnType<typeof useNavigate>;
-	readonly eidInfo: PatientIdFields;
+	readonly eidInfo: EidFields;
 	readonly open: boolean;
 	readonly onConfirm: () => void;
 	readonly onCancel: () => void;

--- a/imports/ui/eid/EidCardDialog.tsx
+++ b/imports/ui/eid/EidCardDialog.tsx
@@ -15,23 +15,30 @@ type Props = {
 	readonly navigate: ReturnType<typeof useNavigate>;
 	readonly eidInfo: PatientIdFields;
 	readonly open: boolean;
-	readonly onClose: () => void;
+	readonly onConfirm: () => void;
+	readonly onCancel: () => void;
 };
 
-const EidCardDialog = ({navigate, eidInfo, open, onClose}: Props) => {
+const EidCardDialog = ({
+	navigate,
+	eidInfo,
+	open,
+	onConfirm,
+	onCancel,
+}: Props) => {
 	const [selected, setSelected] = useState(new Set<string>());
 	const [step, setStep] = useState('selection');
 
 	const selectionIsSingle = selected.size === 1;
 
 	return (
-		<Dialog open={open} onClose={onClose}>
+		<Dialog open={open} onClose={onCancel}>
 			{step === 'selection' && (
 				<EidCardDialogStepSelection
 					eidInfo={eidInfo}
 					selected={selected}
 					setSelected={setSelected}
-					onClose={onClose}
+					onClose={onCancel}
 					onNext={() => {
 						setStep('preview');
 					}}
@@ -45,7 +52,7 @@ const EidCardDialog = ({navigate, eidInfo, open, onClose}: Props) => {
 					onPrevStep={() => {
 						setStep('selection');
 					}}
-					onClose={onClose}
+					onConfirm={onConfirm}
 				/>
 			)}
 			{step === 'preview' && !selectionIsSingle && (

--- a/imports/ui/eid/EidCardDialogStepPreviewSingleCreate.tsx
+++ b/imports/ui/eid/EidCardDialogStepPreviewSingleCreate.tsx
@@ -15,7 +15,7 @@ import SkipPreviousIcon from '@mui/icons-material/SkipPrevious';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 
 import patientsInsert from '../../api/endpoint/patients/insert';
-import {patients} from '../../api/patients';
+import {patientFieldsFromEid, patients} from '../../api/patients';
 
 import useDialog from '../modal/useDialog';
 import ConfirmationDialog from '../modal/ConfirmationDialog';
@@ -55,7 +55,7 @@ const EidCardDialogStepPreviewSingleCreate = ({
 			))
 		) {
 			try {
-				const _id = await call(patientsInsert, eidInfo);
+				const _id = await call(patientsInsert, patientFieldsFromEid(eidInfo));
 				navigate({pathname: `/patient/${_id}`});
 				onConfirm();
 			} catch (error: unknown) {
@@ -64,7 +64,7 @@ const EidCardDialogStepPreviewSingleCreate = ({
 		}
 	};
 
-	const {$set} = patients.sanitize(eidInfo);
+	const {$set} = patients.sanitize(patientFieldsFromEid(eidInfo));
 
 	const eidPatient = {
 		firstname: '',

--- a/imports/ui/eid/EidCardDialogStepPreviewSingleCreate.tsx
+++ b/imports/ui/eid/EidCardDialogStepPreviewSingleCreate.tsx
@@ -31,7 +31,7 @@ const EidCardDialogStepPreviewSingleCreate = ({
 	patientId,
 	eidInfo,
 	navigate,
-	onClose,
+	onConfirm,
 }: EidCardDialogStepPreviewSingleProps) => {
 	assert(patientId === '?');
 	const dialog = useDialog();
@@ -57,7 +57,7 @@ const EidCardDialogStepPreviewSingleCreate = ({
 			try {
 				const _id = await call(patientsInsert, eidInfo);
 				navigate({pathname: `/patient/${_id}`});
-				onClose();
+				onConfirm();
 			} catch (error: unknown) {
 				console.error(error);
 			}

--- a/imports/ui/eid/EidCardDialogStepPreviewSingleCreate.tsx
+++ b/imports/ui/eid/EidCardDialogStepPreviewSingleCreate.tsx
@@ -14,7 +14,7 @@ import SkipNextIcon from '@mui/icons-material/SkipNext';
 import SkipPreviousIcon from '@mui/icons-material/SkipPrevious';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 
-import patientsInsert from '../../api/endpoint/patients/insert';
+import patientsInsertFromEid from '../../api/endpoint/patients/insertFromEid';
 import {patientFieldsFromEid, patients} from '../../api/patients';
 
 import useDialog from '../modal/useDialog';
@@ -55,7 +55,7 @@ const EidCardDialogStepPreviewSingleCreate = ({
 			))
 		) {
 			try {
-				const _id = await call(patientsInsert, patientFieldsFromEid(eidInfo));
+				const _id = await call(patientsInsertFromEid, eidInfo);
 				navigate({pathname: `/patient/${_id}`});
 				onConfirm();
 			} catch (error: unknown) {

--- a/imports/ui/eid/EidCardDialogStepPreviewSingleProps.ts
+++ b/imports/ui/eid/EidCardDialogStepPreviewSingleProps.ts
@@ -8,6 +8,6 @@ type Props = {
 	patientId: string;
 	eidInfo: PatientIdFields;
 	navigate: ReturnType<typeof useNavigate>;
-	onClose: () => void;
+	onConfirm: () => void;
 };
 export default Props;

--- a/imports/ui/eid/EidCardDialogStepPreviewSingleProps.ts
+++ b/imports/ui/eid/EidCardDialogStepPreviewSingleProps.ts
@@ -1,12 +1,12 @@
 import {type useNavigate} from 'react-router-dom';
 
-import {type PatientIdFields} from '../../api/collection/patients';
+import {type EidFields} from '../../api/collection/eids';
 
 type Props = {
 	titleId?: string;
 	onPrevStep: () => void;
 	patientId: string;
-	eidInfo: PatientIdFields;
+	eidInfo: EidFields;
 	navigate: ReturnType<typeof useNavigate>;
 	onConfirm: () => void;
 };

--- a/imports/ui/eid/EidCardDialogStepPreviewSingleUpdate.tsx
+++ b/imports/ui/eid/EidCardDialogStepPreviewSingleUpdate.tsx
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import React from 'react';
+import React, {useCallback} from 'react';
 
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -31,6 +31,8 @@ import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import {red, green} from '@mui/material/colors';
 
 import LoadingButton from '@mui/lab/LoadingButton';
+
+import {useSnackbar} from 'notistack';
 
 import diff from '../../lib/lcs/diff';
 import pngDataURL from '../../lib/png/dataURL';
@@ -150,12 +152,14 @@ const EidCardDialogStepPreviewSingleUpdate = ({
 }: EidCardDialogStepPreviewSingleProps) => {
 	const dialog = useDialog();
 	const [call, {pending}] = useCall();
-	const onOpen = () => {
+	const {enqueueSnackbar} = useSnackbar();
+
+	const onOpen = useCallback(() => {
 		navigate(`/patient/${patientId}`);
 		onConfirm();
-	};
+	}, [navigate, onConfirm]);
 
-	const onNext = async () => {
+	const onNext = useCallback(async () => {
 		if (
 			await dialog((resolve) => (
 				<ConfirmationDialog
@@ -179,9 +183,23 @@ const EidCardDialogStepPreviewSingleUpdate = ({
 				onOpen();
 			} catch (error: unknown) {
 				console.error(error);
+				enqueueSnackbar(
+					`Updating patient with eid info failed: ${
+						error instanceof Error ? error.message : 'unknown'
+					}.`,
+					{variant: 'error'},
+				);
 			}
 		}
-	};
+	}, [
+		enqueueSnackbar,
+		dialog,
+		EditAttributesIcon,
+		call,
+		patientId,
+		eidInfo,
+		onOpen,
+	]);
 
 	const {$set} = patients.sanitize(patientFieldsFromEid(eidInfo));
 	const eidPatients = [{_id: '?', ...$set}];

--- a/imports/ui/eid/EidCardDialogStepPreviewSingleUpdate.tsx
+++ b/imports/ui/eid/EidCardDialogStepPreviewSingleUpdate.tsx
@@ -146,13 +146,13 @@ const EidCardDialogStepPreviewSingleUpdate = ({
 	patientId,
 	eidInfo,
 	navigate,
-	onClose,
+	onConfirm,
 }: EidCardDialogStepPreviewSingleProps) => {
 	const dialog = useDialog();
 	const [call, {pending}] = useCall();
 	const onOpen = () => {
 		navigate(`/patient/${patientId}`);
-		onClose();
+		onConfirm();
 	};
 
 	const onNext = async () => {

--- a/imports/ui/eid/EidCardDialogStepPreviewSingleUpdate.tsx
+++ b/imports/ui/eid/EidCardDialogStepPreviewSingleUpdate.tsx
@@ -36,7 +36,7 @@ import diff from '../../lib/lcs/diff';
 import pngDataURL from '../../lib/png/dataURL';
 
 import patientsUpdate from '../../api/endpoint/patients/update';
-import {patients} from '../../api/patients';
+import {patientFieldsFromEid, patients} from '../../api/patients';
 
 import useDialog from '../modal/useDialog';
 import ConfirmationDialog from '../modal/ConfirmationDialog';
@@ -175,7 +175,7 @@ const EidCardDialogStepPreviewSingleUpdate = ({
 			))
 		) {
 			try {
-				await call(patientsUpdate, patientId, eidInfo);
+				await call(patientsUpdate, patientId, patientFieldsFromEid(eidInfo));
 				onOpen();
 			} catch (error: unknown) {
 				console.error(error);
@@ -183,7 +183,7 @@ const EidCardDialogStepPreviewSingleUpdate = ({
 		}
 	};
 
-	const {$set} = patients.sanitize(eidInfo);
+	const {$set} = patients.sanitize(patientFieldsFromEid(eidInfo));
 	const eidPatients = [{_id: '?', ...$set}];
 	const selectedPatient = {_id: patientId};
 	const selectedPatients = [selectedPatient];

--- a/imports/ui/eid/EidCardDialogStepPreviewSingleUpdate.tsx
+++ b/imports/ui/eid/EidCardDialogStepPreviewSingleUpdate.tsx
@@ -37,7 +37,7 @@ import {useSnackbar} from 'notistack';
 import diff from '../../lib/lcs/diff';
 import pngDataURL from '../../lib/png/dataURL';
 
-import patientsUpdate from '../../api/endpoint/patients/update';
+import patientsUpdateFromEid from '../../api/endpoint/patients/updateFromEid';
 import {patientFieldsFromEid, patients} from '../../api/patients';
 
 import useDialog from '../modal/useDialog';
@@ -179,7 +179,7 @@ const EidCardDialogStepPreviewSingleUpdate = ({
 			))
 		) {
 			try {
-				await call(patientsUpdate, patientId, patientFieldsFromEid(eidInfo));
+				await call(patientsUpdateFromEid, patientId, eidInfo);
 				onOpen();
 			} catch (error: unknown) {
 				console.error(error);

--- a/imports/ui/eid/EidCardDialogStepSelection.tsx
+++ b/imports/ui/eid/EidCardDialogStepSelection.tsx
@@ -32,11 +32,8 @@ import CancelButton from '../button/CancelButton';
 
 import mergeFields from '../../api/query/mergeFields';
 
-import {
-	type PatientDocument,
-	type PatientIdFields,
-} from '../../api/collection/patients';
-import {patients} from '../../api/patients';
+import {type PatientDocument} from '../../api/collection/patients';
+import {patientFieldsFromEid, patients} from '../../api/patients';
 import {onlyNumeric} from '../../api/string';
 
 import useDialog from '../modal/useDialog';
@@ -49,6 +46,7 @@ import SelectablePatientCard from '../patients/SelectablePatientCard';
 import ReactivePatientCard from '../patients/ReactivePatientCard';
 import GenericNewPatientCard from '../patients/GenericNewPatientCard';
 import PatientsGrid from '../patients/PatientsGrid';
+import {type EidFields} from '../../api/collection/eids';
 
 const DEFAULT_LIMIT = 3;
 const DEFAULT_FIELDS = {
@@ -129,7 +127,7 @@ type Props = {
 	readonly titleId?: string;
 	readonly onClose: () => void;
 	readonly onNext: () => void;
-	readonly eidInfo: PatientIdFields;
+	readonly eidInfo: EidFields;
 	readonly selected: Set<string>;
 	readonly setSelected: (selection: Set<string>) => void;
 };
@@ -145,7 +143,7 @@ const EidCardDialogStepSelection = ({
 	const {classes, cx} = useStyles();
 	const dialog = useDialog();
 
-	const {$set} = patients.sanitize(eidInfo);
+	const {$set} = patients.sanitize(patientFieldsFromEid(eidInfo));
 	const eidPatient = {_id: '?', ...$set};
 	const normalizedName = patients.normalizedName(
 		eidPatient.firstname,

--- a/test/README.md
+++ b/test/README.md
@@ -24,16 +24,16 @@
     - [x] Logging out
 
   - [ ] Patients
-    - [ ] Create
+    - [x] Create
       - [x] Create patient from scratch
-      - [ ] Create patient from eID
+      - [x] Create patient from eID
     - [ ] Read
       - [x] Search
       - [ ] Search including deceased
-    - [ ] Update
+    - [x] Update
       - [x] Patient personal info edition
-      - [ ] Update patient from eID
-      - [ ] eID noop when already up-to-date
+      - [x] Update patient from eID
+      - [x] eID noop when already up-to-date
       - [x] Patient merge (~`integration`~)
     - [ ] Delete
       - [ ] Mark patient as deceased

--- a/test/app/client/patient/eids.app-tests.ts
+++ b/test/app/client/patient/eids.app-tests.ts
@@ -1,0 +1,137 @@
+import {fireEvent} from '@testing-library/dom';
+
+import createUserWithPassword from '../../../../imports/api/user/createUserWithPassword';
+
+import {exampleEidXML} from '../../../../imports/api/_dev/populate/eids';
+
+import {
+	client,
+	randomPassword,
+	randomUserId,
+} from '../../../../imports/_test/fixtures';
+import {setupApp, searchForPatient} from '../fixtures';
+
+type Item = string | File;
+
+const createFileList = (files: File[]): FileList => {
+	const list: FileList & Iterable<File> = {
+		...files,
+		length: files.length,
+		item: (index: number) => list[index]!,
+		[Symbol.iterator]: () => files[Symbol.iterator](),
+	};
+	list.constructor = FileList;
+	Object.setPrototypeOf(list, FileList.prototype);
+	Object.freeze(list);
+
+	return list;
+};
+
+const itemToDataTransferItem = (item: Item) =>
+	item instanceof File
+		? {
+				kind: 'file',
+				type: item.type,
+				getAsFile: () => item,
+		  }
+		: {
+				kind: 'string',
+				type: 'text/plain',
+				getAsString(resolve: (value: string) => void) {
+					resolve(item);
+				},
+		  };
+
+const createItemList = (items: Item[]): DataTransferItemList => {
+	const list: DataTransferItemList & Iterable<DataTransferItem> = {
+		...items.map(itemToDataTransferItem),
+		length: items.length,
+		add() {
+			throw new Error('not-implemented');
+		},
+		remove() {
+			throw new Error('not-implemented');
+		},
+		clear() {
+			throw new Error('not-implemented');
+		},
+		*[Symbol.iterator]() {
+			// eslint-disable-next-line unicorn/no-for-loop,@typescript-eslint/prefer-for-of
+			for (let i = 0; i < list.length; ++i) {
+				yield list[i]!;
+			}
+		},
+	};
+
+	list.constructor = DataTransferItemList;
+	Object.setPrototypeOf(list, DataTransferItemList.prototype);
+	Object.freeze(list);
+
+	return list;
+};
+
+const createDataTransferFromFiles = (items: Item[] = []): DataTransfer => {
+	const dt = new DataTransfer();
+	Object.defineProperty(dt, 'files', {
+		get: () =>
+			createFileList(
+				items.filter((item: Item): item is File => item instanceof File),
+			),
+	});
+	Object.defineProperty(dt, 'items', {get: () => createItemList(items)});
+	return dt;
+};
+
+const dropFiles = async ({findByLabelText}, item: Item) => {
+	fireEvent.drop(await findByLabelText(/drop contents here/i), {
+		dataTransfer: createDataTransferFromFiles([item]),
+	});
+};
+
+client(__filename, () => {
+	it('should allow to open and close eid dialog', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		const app = setupApp();
+		await createUserWithPassword(username, password);
+
+		const {findByRole, findByText, user} = app;
+
+		await dropFiles(app, exampleEidXML());
+
+		await findByRole('heading', {name: 'Select record to work with.'});
+
+		await user.click(await findByRole('button', {name: 'Cancel'}));
+
+		await findByText('Closed eid dialog.');
+	});
+
+	it('should allow to create a patient from eid', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		const app = setupApp();
+		await createUserWithPassword(username, password);
+
+		const {findByRole, user} = app;
+
+		const eidXML = exampleEidXML({name: 'Doe', firstname: 'Jane'});
+
+		await dropFiles(app, eidXML);
+
+		await findByRole('heading', {name: 'Select record to work with.'});
+
+		await user.click(await findByRole('button', {name: 'Add a new patient'}));
+
+		await user.click(await findByRole('button', {name: 'Next (1)'}));
+
+		await user.click(await findByRole('button', {name: 'Next'}));
+
+		await user.click(
+			await findByRole('button', {name: 'Create a new patient'}),
+		);
+
+		await searchForPatient(app, 'Jane Doe', {
+			name: 'Jane Doe',
+		});
+	});
+});

--- a/test/app/client/patient/eids.app-tests.ts
+++ b/test/app/client/patient/eids.app-tests.ts
@@ -192,4 +192,46 @@ client(__filename, () => {
 
 		await findByRole('heading', {name: `/patient/${patientId}`});
 	});
+
+	it('should allow to update a patient from eid', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		const app = setupApp();
+		await createUserWithPassword(username, password);
+
+		const {findAllByRole, findByRole, findByText, user} = app;
+
+		const formData = newPatientFormData({
+			streetandnumber: 'streetandnumber-initial',
+		});
+
+		const {firstname, lastname} = formData;
+
+		const patientId = await call(insert, formData);
+
+		const eidXML = exampleEidXML({
+			name: lastname,
+			firstname,
+			streetandnumber: 'streetandnumber-eid',
+		});
+
+		await dropFiles(app, eidXML);
+
+		await findByRole('heading', {name: 'Select record to work with.'});
+
+		const buttons = await findAllByRole('button', {
+			name: new RegExp(`\\b${lastname} ${firstname}\\b`, 'i'),
+		});
+		await user.click(buttons[0]!);
+
+		await user.click(await findByRole('button', {name: 'Next (1)'}));
+
+		await user.click(await findByRole('button', {name: 'Next'}));
+
+		await user.click(await findByRole('button', {name: 'Update'}));
+
+		await findByRole('heading', {name: `/patient/${patientId}`});
+
+		await findByText('streetandnumber-eid');
+	});
 });


### PR DESCRIPTION
This fixes the following issues:
  - Fixes #5 

This is progress on the following issues:
  - #1020 

Most relevant changes:
- 48e3dbe5 :microscope: test: Increase coverage target to 73%.
- 2d72f8be :construction: progress: Record patient changes on insert/update.
- c835a95e :sparkles: feat(eid): Insert eid info into database on patient update.
- fb0f8aa6 :sparkles: feat(eid): Insert eid info into database on patient creation.
- f04c925a :test_tube: test(eid): Cover deleting patients after they have been selected.
- 12c16c08 :test_tube: test(eid): Add app test to cover updating patient from eid.
- 09405fa6 :test_tube: test(eid): Add app test to cover accessing patient from eid.
- 06704573 :test_tube: test(eid): Cover creating a new patient from eid.