### PR TITLE
Fix image tagging for semver releases

### DIFF
--- a/.github/workflows/ci:build:image.yml
+++ b/.github/workflows/ci:build:image.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=tag,enable={{is_default_branch}}
+            type=ref,event=tag
             type=ref,event=branch
             type=ref,event=pr
             type=sha,format=long


### PR DESCRIPTION
[`{{is_default_branch}}`](https://github.com/docker/metadata-action?tab=readme-ov-file#is_default_branch) does not seem to work on `push tag` events.