### PR TITLE
Upgrade MongoDB compose deployment to v7.0.5.

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 ROOT_URL=http://localhost
 PORT=3000
 
-MONGO_VERSION=5.0
+MONGO_VERSION=7.0.5
 MONGO_URL=mongodb://patient-db:27017/meteor
 MONGO_OPLOG_URL=""
 

--- a/.github/workflows/ci:build.yml
+++ b/.github/workflows/ci:build.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Start MongoDB container
         env:
-          MONGO_VERSION: '5.0'
+          MONGO_VERSION: '7.0.5'
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/data/db"
           docker container run \

--- a/.github/workflows/ci:build:image.yml
+++ b/.github/workflows/ci:build:image.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Start MongoDB container
         env:
-          MONGO_VERSION: '5.0'
+          MONGO_VERSION: '7.0.5'
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/data/db"
           docker container run \


### PR DESCRIPTION
This is necessary to be able to use `$changeStreamSplitLargeEvent`. MongoDB v7.0.5 is supported since Meteor v2.15.0.

See https://v2-docs.meteor.com/changelog#v215020240205.

 - This is progress on #955. It does not "fix" it since we still need to implement
    - #797 