### PR TITLE
Fix bouncy database synchronization of settings inputs and color pickers

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 73%
+        target: 75%
         threshold: 1%
     patch:
       default:

--- a/imports/api/settings.ts
+++ b/imports/api/settings.ts
@@ -12,8 +12,8 @@ import findOneSync from './publication/findOneSync';
 
 export type UserSettings = {
 	'theme-palette-mode': PaletteMode;
-	'theme-palette-primary': (typeof indigo)[500];
-	'theme-palette-secondary': typeof pink.A400;
+	'theme-palette-primary': string;
+	'theme-palette-secondary': string;
 	'navigation-drawer-is-open': 'open' | 'closed';
 	'books-sorting-order': -1 | 1;
 	currency: 'EUR';

--- a/imports/ui/allergies/ReactiveAllergyCard.tests.tsx
+++ b/imports/ui/allergies/ReactiveAllergyCard.tests.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import {faker} from '@faker-js/faker';
+
+import {assert} from 'chai';
+
+import {BrowserRouter} from 'react-router-dom';
+
+import call from '../../api/endpoint/call';
+import createUserWithPassword from '../../api/user/createUserWithPassword';
+import loginWithPassword from '../../api/user/loginWithPassword';
+import {client, randomPassword, randomUserId} from '../../_test/fixtures';
+import {newPatientFormData} from '../../api/_dev/populate/patients';
+
+import patientsInsert from '../../api/endpoint/patients/insert';
+import {render} from '../../_test/react';
+
+import {type FormattedLine, type NormalizedLine} from '../../api/string';
+
+import ReactiveAllergyCard from './ReactiveAllergyCard';
+
+client(__filename, () => {
+	it("should allow to change allergy's color", async () => {
+		const {setupUser} = await import('../../../test/app/client/fixtures');
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPassword(username, password);
+		await loginWithPassword(username, password);
+
+		const allergy = {
+			displayName: 'Orange' as FormattedLine,
+			name: 'orange' as NormalizedLine,
+		};
+
+		await call(
+			patientsInsert,
+			newPatientFormData({
+				allergies: [allergy],
+			}),
+		);
+
+		const {findByRole} = render(
+			<BrowserRouter>
+				<ReactiveAllergyCard item={allergy} />
+			</BrowserRouter>,
+		);
+
+		const button = await findByRole('button', {name: 'Color for orange'});
+
+		const {user} = setupUser();
+
+		await user.click(button);
+		const hex = await findByRole('textbox', {name: 'hex'});
+
+		const validInput = faker.color.rgb().toUpperCase();
+
+		await user.clear(hex);
+		await user.paste(validInput);
+
+		assert.strictEqual(button.textContent?.toUpperCase(), validInput);
+	});
+});

--- a/imports/ui/allergies/StaticAllergyCard.tsx
+++ b/imports/ui/allergies/StaticAllergyCard.tsx
@@ -23,6 +23,8 @@ import ColorPicker from '../input/ColorPicker';
 import {myEncodeURIComponent} from '../../lib/uri';
 import changeColor from '../../api/endpoint/allergies/changeColor';
 
+import {TIMEOUT_INPUT_DEBOUNCE} from '../constants';
+
 import AllergyRenamingDialog from './AllergyRenamingDialog';
 import AllergyDeletionDialog from './AllergyDeletionDialog';
 
@@ -80,7 +82,7 @@ const LoadedTagCard = React.forwardRef<any, LoadedTagCardProps>(
 							console.error(error);
 						}
 					}
-				}, 1000),
+				}, TIMEOUT_INPUT_DEBOUNCE),
 			[_id, color],
 		);
 

--- a/imports/ui/allergies/StaticAllergyCard.tsx
+++ b/imports/ui/allergies/StaticAllergyCard.tsx
@@ -140,6 +140,7 @@ const LoadedTagCard = React.forwardRef<any, LoadedTagCardProps>(
 				content={content}
 				actions={
 					<ColorPicker
+						aria-label={`Color for ${name}`}
 						defaultValue={clientValue ?? '#e0e0e0'}
 						onChange={onChange}
 					/>

--- a/imports/ui/hooks/useIsMounted.ts
+++ b/imports/ui/hooks/useIsMounted.ts
@@ -1,4 +1,4 @@
-import {useRef, useEffect} from 'react';
+import {useRef, useEffect, useCallback} from 'react';
 
 /**
  * See https://gist.github.com/jaydenseric/a67cfb1b809b1b789daa17dfe6f83daa
@@ -16,7 +16,7 @@ const useIsMounted = () => {
 		};
 	}, []);
 
-	return () => componentIsMounted.current;
+	return useCallback(() => componentIsMounted.current, [componentIsMounted]);
 };
 
 export default useIsMounted;

--- a/imports/ui/hooks/useLastTruthyValue.ts
+++ b/imports/ui/hooks/useLastTruthyValue.ts
@@ -1,9 +1,8 @@
-import {useRef} from 'react';
+import useReduce from './useReduce';
 
-const useLastTruthyValue = (value: any) => {
-	const ref = useRef<any>(undefined);
-	ref.current = value || ref.current;
-	return ref.current;
-};
+const lastTruthyValue = (acc: any, value: any) => value || acc;
+
+const useLastTruthyValue = (value: any) =>
+	useReduce(lastTruthyValue, value, undefined);
 
 export default useLastTruthyValue;

--- a/imports/ui/hooks/useReduce.ts
+++ b/imports/ui/hooks/useReduce.ts
@@ -1,0 +1,13 @@
+import {useRef} from 'react';
+
+const useReduce = <A, T>(
+	reduce: (acc: A, value: T) => A,
+	value: T,
+	init: A,
+) => {
+	const ref = useRef<A>(init);
+	ref.current = reduce(ref.current, value);
+	return ref.current;
+};
+
+export default useReduce;

--- a/imports/ui/input/ColorPicker/components/ColorPicker.tests.tsx
+++ b/imports/ui/input/ColorPicker/components/ColorPicker.tests.tsx
@@ -1,6 +1,7 @@
+import {faker} from '@faker-js/faker';
 import React from 'react';
 
-import {client} from '../../../../_test/fixtures';
+import {client, throws} from '../../../../_test/fixtures';
 import {render, waitForElementToBeRemoved} from '../../../../_test/react';
 
 import ColorPicker from './ColorPicker';
@@ -28,5 +29,38 @@ client(__filename, () => {
 			waitForElementToBeRemoved(hex),
 			user.keyboard('{Escape}'),
 		]);
+	});
+
+	it('should NOT close picker dialog on {Escape} when input is focused', async () => {
+		const {setupUser} = await import('../../../../../test/app/client/fixtures');
+		const {findByRole} = render(
+			<ColorPicker
+				aria-label="test-label"
+				defaultValue="#000"
+				// eslint-disable-next-line @typescript-eslint/no-empty-function
+				onChange={() => {}}
+			/>,
+		);
+
+		const button = await findByRole('button', {name: 'test-label'});
+
+		const {user} = setupUser();
+		await user.click(button);
+
+		const hex = await findByRole('textbox', {name: 'hex'});
+
+		const validInput = faker.color.rgb().toUpperCase();
+
+		await user.clear(hex);
+		await user.paste(validInput);
+
+		await throws(
+			async () =>
+				Promise.all([
+					waitForElementToBeRemoved(hex),
+					user.keyboard('{Escape}'),
+				]),
+			/Timed out in waitForElementToBeRemoved/,
+		);
 	});
 });

--- a/imports/ui/input/ColorPicker/components/ColorPicker.tests.tsx
+++ b/imports/ui/input/ColorPicker/components/ColorPicker.tests.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import {client} from '../../../../_test/fixtures';
+import {render, waitForElementToBeRemoved} from '../../../../_test/react';
+
+import ColorPicker from './ColorPicker';
+
+client(__filename, () => {
+	it('should close picker dialog on {Escape}', async () => {
+		const {setupUser} = await import('../../../../../test/app/client/fixtures');
+		const {findByRole} = render(
+			<ColorPicker
+				aria-label="test-label"
+				defaultValue="#000"
+				// eslint-disable-next-line @typescript-eslint/no-empty-function
+				onChange={() => {}}
+			/>,
+		);
+
+		const button = await findByRole('button', {name: 'test-label'});
+
+		const {user} = setupUser();
+		await user.click(button);
+
+		const hex = await findByRole('textbox', {name: 'hex'});
+
+		await Promise.all([
+			waitForElementToBeRemoved(hex),
+			user.keyboard('{Escape}'),
+		]);
+	});
+});

--- a/imports/ui/input/ColorPicker/components/ColorPicker.tests.tsx
+++ b/imports/ui/input/ColorPicker/components/ColorPicker.tests.tsx
@@ -63,4 +63,34 @@ client(__filename, () => {
 			/Timed out in waitForElementToBeRemoved/,
 		);
 	});
+
+	it('should close picker dialog on {Escape} after leaving input', async () => {
+		const {setupUser} = await import('../../../../../test/app/client/fixtures');
+		const {findByRole} = render(
+			<ColorPicker
+				aria-label="test-label"
+				defaultValue="#000"
+				// eslint-disable-next-line @typescript-eslint/no-empty-function
+				onChange={() => {}}
+			/>,
+		);
+
+		const button = await findByRole('button', {name: 'test-label'});
+
+		const {user} = setupUser();
+		await user.click(button);
+
+		const hex = await findByRole('textbox', {name: 'hex'});
+
+		const validInput = faker.color.rgb().toUpperCase();
+
+		await user.clear(hex);
+		await user.paste(validInput);
+
+		await Promise.all([
+			waitForElementToBeRemoved(hex),
+			user.keyboard('{Tab}'),
+			user.keyboard('{Escape}'),
+		]);
+	});
 });

--- a/imports/ui/input/ColorPicker/components/ColorPicker.tsx
+++ b/imports/ui/input/ColorPicker/components/ColorPicker.tsx
@@ -7,6 +7,8 @@ import ColorLensIcon from '@mui/icons-material/ColorLens';
 
 import color from '../../../../lib/color';
 
+import useChanged from '../../../hooks/useChanged';
+
 import {DEFAULT_CONVERTER, converters} from '../transformers';
 
 import PickerDialog from './PickerDialog';
@@ -26,15 +28,13 @@ const ColorPicker = ({
 }: Props) => {
 	const [showPicker, setShowPicker] = useState(false);
 	const [value, setValue] = useState(defaultValue);
-	const [previousDefaultValue, setPreviousDefaultValue] =
-		useState(defaultValue);
+	const changed = useChanged([defaultValue]);
 
 	useEffect(() => {
-		if (defaultValue !== previousDefaultValue) {
-			setPreviousDefaultValue(defaultValue);
+		if (changed) {
 			setValue(defaultValue);
 		}
-	}, [defaultValue, previousDefaultValue]);
+	}, [changed, defaultValue]);
 
 	return (
 		<span>

--- a/imports/ui/input/ColorPicker/components/ColorPicker.tsx
+++ b/imports/ui/input/ColorPicker/components/ColorPicker.tsx
@@ -14,6 +14,7 @@ import {DEFAULT_CONVERTER, converters} from '../transformers';
 import PickerDialog from './PickerDialog';
 
 type Props = {
+	readonly 'aria-label'?: string;
 	readonly defaultValue: string;
 	readonly onChange: (color: string) => void;
 	readonly convert?: keyof typeof converters;
@@ -21,6 +22,7 @@ type Props = {
 };
 
 const ColorPicker = ({
+	'aria-label': ariaLabel,
 	defaultValue,
 	onChange,
 	convert = DEFAULT_CONVERTER,
@@ -49,6 +51,7 @@ const ColorPicker = ({
 					color: color(value).isLight() ? '#111' : '#ddd',
 				}}
 				label={value}
+				aria-label={ariaLabel}
 				onClick={
 					readOnly
 						? undefined

--- a/imports/ui/input/ColorPicker/components/ColorPicker.tsx
+++ b/imports/ui/input/ColorPicker/components/ColorPicker.tsx
@@ -63,7 +63,7 @@ const ColorPicker = ({
 			{!readOnly && showPicker && (
 				<PickerDialog
 					value={value}
-					onClick={() => {
+					onClose={() => {
 						setShowPicker(false);
 						onChange(value);
 					}}

--- a/imports/ui/input/ColorPicker/components/PickerDialog.tsx
+++ b/imports/ui/input/ColorPicker/components/PickerDialog.tsx
@@ -1,26 +1,52 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {ChromePicker, type Color, type ColorChangeHandler} from 'react-color';
 
 type Props = {
 	readonly value: Color;
 	readonly onChange: ColorChangeHandler;
-	readonly onClick: () => void;
+	readonly onClose: () => void;
 };
 
-const PickerDialog = ({value, onClick, onChange}: Props) => (
-	<div style={{position: 'absolute', zIndex: 2}}>
-		<div
-			style={{
-				position: 'fixed',
-				top: '0px',
-				right: '0px',
-				bottom: '0px',
-				left: '0px',
-			}}
-			onClick={onClick}
-		/>
-		<ChromePicker color={value} onChange={onChange} />
-	</div>
-);
+const _isTextBox = (
+	element: Element | null,
+): element is HTMLInputElement | HTMLTextAreaElement => {
+	return element?.tagName.match(/input|textarea/i) !== null;
+};
+
+const PickerDialog = ({value, onClose, onChange}: Props) => {
+	useEffect(() => {
+		const closeOnEscape = (event: KeyboardEvent) => {
+			if (event.key !== 'Escape') return;
+
+			// NOTE: Ignore keys pressed when inside a text box.
+			const {activeElement} = document;
+			if (event.target === activeElement && _isTextBox(activeElement)) return;
+
+			event.stopPropagation();
+			onClose();
+		};
+
+		document.addEventListener('keydown', closeOnEscape);
+		return () => {
+			document.removeEventListener('keydown', closeOnEscape);
+		};
+	}, [onClose]);
+
+	return (
+		<div style={{position: 'absolute', zIndex: 2}}>
+			<div
+				style={{
+					position: 'fixed',
+					top: '0px',
+					right: '0px',
+					bottom: '0px',
+					left: '0px',
+				}}
+				onClick={onClose}
+			/>
+			<ChromePicker color={value} onChange={onChange} />
+		</div>
+	);
+};
 
 export default PickerDialog;

--- a/imports/ui/settings/AccountHolderSetting.tests.tsx
+++ b/imports/ui/settings/AccountHolderSetting.tests.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import {assert} from 'chai';
+import {faker} from '@faker-js/faker';
+
+import createUserWithPassword from '../../api/user/createUserWithPassword';
+import loginWithPassword from '../../api/user/loginWithPassword';
+import {client, randomPassword, randomUserId} from '../../_test/fixtures';
+import {render, waitFor} from '../../_test/react';
+
+import {setSetting} from './hooks';
+import AccountHolderSetting from './AccountHolderSetting';
+
+client(__filename, () => {
+	it('loads saved value', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPassword(username, password);
+		await loginWithPassword(username, password);
+		const value = faker.company.name();
+		await setSetting('account-holder', value);
+
+		const {findByLabelText} = render(<AccountHolderSetting />);
+
+		const accountHolder = (await findByLabelText('Account Holder', {
+			selector: 'input:not([disabled])',
+		})) as HTMLInputElement;
+
+		await waitFor(() => {
+			// NOTE: Current implementation has spurious transient states.
+			assert.notStrictEqual(accountHolder.value, '');
+		});
+
+		// NOTE: Input is enabled once initial value is loaded.
+		assert.strictEqual(accountHolder.value, value);
+	});
+});

--- a/imports/ui/settings/AccountHolderSetting.tsx
+++ b/imports/ui/settings/AccountHolderSetting.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 
 import InputOneSetting from './InputOneSetting';
 
-export default function AccountHolderSetting({className}) {
+type Props = {
+	readonly className?: string;
+};
+
+export default function AccountHolderSetting({className}: Props) {
 	return (
 		<InputOneSetting
 			className={className}

--- a/imports/ui/settings/AccountHolderSetting.tsx
+++ b/imports/ui/settings/AccountHolderSetting.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import InputOneSetting from './InputOneSetting';
 
-export default function IBANSetting({className}) {
+export default function AccountHolderSetting({className}) {
 	return (
 		<InputOneSetting
 			className={className}

--- a/imports/ui/settings/IBANSetting.tests.tsx
+++ b/imports/ui/settings/IBANSetting.tests.tsx
@@ -34,4 +34,27 @@ client(__filename, () => {
 		// NOTE: Input is enabled once initial value is loaded.
 		assert.strictEqual(iban.value, value);
 	});
+
+	it('sanitizes input when typing', async () => {
+		const {fillIn, setupUser} = await import(
+			'../../../test/app/client/fixtures'
+		);
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPassword(username, password);
+		await loginWithPassword(username, password);
+
+		const {findByLabelText} = render(<IBANSetting />);
+
+		const iban = (await findByLabelText('IBAN', {
+			selector: 'input:not([disabled])',
+		})) as HTMLInputElement;
+
+		const {user} = setupUser();
+
+		const validInput = faker.finance.iban({formatted: true});
+		await fillIn({user}, iban, validInput);
+
+		assert.strictEqual(iban.value, validInput.replaceAll(' ', ''));
+	});
 });

--- a/imports/ui/settings/IBANSetting.tests.tsx
+++ b/imports/ui/settings/IBANSetting.tests.tsx
@@ -57,4 +57,26 @@ client(__filename, () => {
 
 		assert.strictEqual(iban.value, validInput.replaceAll(' ', ''));
 	});
+
+	it('sanitizes input when pasting', async () => {
+		const {setupUser} = await import('../../../test/app/client/fixtures');
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPassword(username, password);
+		await loginWithPassword(username, password);
+
+		const {findByLabelText} = render(<IBANSetting />);
+
+		const iban = (await findByLabelText('IBAN', {
+			selector: 'input:not([disabled])',
+		})) as HTMLInputElement;
+
+		const {user} = setupUser();
+
+		const validInput = faker.finance.iban({formatted: true});
+		await user.clear(iban);
+		await user.paste(validInput);
+
+		assert.strictEqual(iban.value, validInput.replaceAll(' ', ''));
+	});
 });

--- a/imports/ui/settings/IBANSetting.tests.tsx
+++ b/imports/ui/settings/IBANSetting.tests.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import {assert} from 'chai';
+import {faker} from '@faker-js/faker';
+
+import createUserWithPassword from '../../api/user/createUserWithPassword';
+import loginWithPassword from '../../api/user/loginWithPassword';
+import {client, randomPassword, randomUserId} from '../../_test/fixtures';
+import {render, waitFor} from '../../_test/react';
+
+import IBANSetting from './IBANSetting';
+import {setSetting} from './hooks';
+
+client(__filename, () => {
+	it('loads saved value', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPassword(username, password);
+		await loginWithPassword(username, password);
+		const value = faker.finance.iban();
+		await setSetting('iban', value);
+
+		const {findByLabelText} = render(<IBANSetting />);
+
+		const iban = (await findByLabelText('IBAN', {
+			selector: 'input:not([disabled])',
+		})) as HTMLInputElement;
+
+		await waitFor(() => {
+			// NOTE: Current implementation has spurious transient states.
+			assert.notStrictEqual(iban.value, '');
+		});
+
+		// NOTE: Input is enabled once initial value is loaded.
+		assert.strictEqual(iban.value, value);
+	});
+});

--- a/imports/ui/settings/IBANSetting.tsx
+++ b/imports/ui/settings/IBANSetting.tsx
@@ -14,7 +14,7 @@ export default function IBANSetting({className}: Props) {
 			className={className}
 			setting="iban"
 			label="IBAN"
-			sanitize={(s) => s.trim()}
+			sanitize={(s) => s.replaceAll(' ', '')}
 			validate={(s) => ({
 				outcome: IBAN.isValid(s) ? 1 : 0,
 			})}

--- a/imports/ui/settings/IBANSetting.tsx
+++ b/imports/ui/settings/IBANSetting.tsx
@@ -4,7 +4,11 @@ import IBAN from 'iban';
 
 import InputOneSetting from './InputOneSetting';
 
-export default function IBANSetting({className}) {
+type Props = {
+	readonly className?: string;
+};
+
+export default function IBANSetting({className}: Props) {
 	return (
 		<InputOneSetting
 			className={className}

--- a/imports/ui/settings/InputOneSetting.tests.tsx
+++ b/imports/ui/settings/InputOneSetting.tests.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import {assert} from 'chai';
+import {faker} from '@faker-js/faker';
+
+import createUserWithPassword from '../../api/user/createUserWithPassword';
+import loginWithPassword from '../../api/user/loginWithPassword';
+import {client, randomPassword, randomUserId} from '../../_test/fixtures';
+import {render} from '../../_test/react';
+
+import {
+	TIMEOUT_INPUT_DEBOUNCE,
+	TIMEOUT_REACTIVITY_DEBOUNCE,
+} from '../constants';
+import sleep from '../../lib/async/sleep';
+
+import InputOneSetting from './InputOneSetting';
+
+client(__filename, () => {
+	it('should allow the user to type fast', async () => {
+		const {fillIn, setupUser} = await import(
+			'../../../test/app/client/fixtures'
+		);
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPassword(username, password);
+		await loginWithPassword(username, password);
+
+		const {findByLabelText} = render(
+			<InputOneSetting label="test-label" setting="account-holder" />,
+		);
+
+		const setting = (await findByLabelText('test-label', {
+			selector: 'input:not([disabled])',
+		})) as HTMLInputElement;
+
+		assert.strictEqual(setting.value, '');
+
+		const {userWithRealisticTypingSpeed: user} = setupUser();
+
+		const validInput = faker.company.name();
+
+		await fillIn({user}, setting, validInput);
+
+		assert.strictEqual(setting.value, validInput);
+
+		await sleep(TIMEOUT_INPUT_DEBOUNCE + TIMEOUT_REACTIVITY_DEBOUNCE * 2);
+
+		assert.strictEqual(setting.value, validInput);
+	}).timeout(10_000);
+});

--- a/imports/ui/settings/InputOneSetting.tsx
+++ b/imports/ui/settings/InputOneSetting.tsx
@@ -47,7 +47,17 @@ const InputOneSetting = <K extends StringSettingKey>({
 	const [debouncedValue, {isPending, flush}] = useDebounce(
 		value as string,
 		TIMEOUT_REACTIVITY_DEBOUNCE,
+		// NOTE: This should really be `{leading: !loading}`, but that does
+		// seem to work as `isPending` returns `true` even when leading update
+		// has been taken into account. See `flush`-based workaround below.
+		// SEE: https://github.com/xnimorz/use-debounce/issues/192
+		{leading: false},
 	);
+	useEffect(() => {
+		// NOTE: Flush when loading is done.
+		if (!loading) flush();
+	}, [loading, flush]);
+
 	const [displayedValue, setDisplayedValue] = useState(value as string);
 	const [ignoreUpdates, setIgnoreUpdates] = useState(false);
 

--- a/imports/ui/settings/InputOneSetting.tsx
+++ b/imports/ui/settings/InputOneSetting.tsx
@@ -29,7 +29,7 @@ type Props<K extends SettingKey> = {
 	readonly label?: string;
 	readonly setting: K;
 	readonly sanitize?: (inputValue: string) => any;
-	readonly validate?: (x: any) => Outcome;
+	readonly validate?: (x: string) => Outcome;
 };
 
 const InputOneSetting = <K extends SettingKey>({

--- a/imports/ui/settings/InputOneSetting.tsx
+++ b/imports/ui/settings/InputOneSetting.tsx
@@ -1,19 +1,11 @@
-import React, {useState, useEffect, useMemo, startTransition} from 'react';
+import React, {useCallback, useMemo, type ChangeEvent} from 'react';
 
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 
-import debounce from 'p-debounce';
-import {useDebounce} from 'use-debounce';
-
 import {type UserSettings, type SettingKey} from '../../api/settings';
 
-import {
-	TIMEOUT_INPUT_DEBOUNCE,
-	TIMEOUT_REACTIVITY_DEBOUNCE,
-} from '../constants';
-
-import {useSetting} from './hooks';
+import {useSettingDebounced} from './hooks';
 
 type Outcome = {
 	outcome: -1 | 0 | 1;
@@ -43,66 +35,20 @@ const InputOneSetting = <K extends StringSettingKey>({
 	label,
 	title,
 }: Props<K>) => {
-	const {loading, value, setValue} = useSetting<K>(setting);
-	const [debouncedValue, {isPending, flush}] = useDebounce(
-		value as string,
-		TIMEOUT_REACTIVITY_DEBOUNCE,
-		// NOTE: This should really be `{leading: !loading}`, but that does
-		// seem to work as `isPending` returns `true` even when leading update
-		// has been taken into account. See `flush`-based workaround below.
-		// SEE: https://github.com/xnimorz/use-debounce/issues/192
-		{leading: false},
-	);
-	useEffect(() => {
-		// NOTE: Flush when loading is done.
-		if (!loading) flush();
-	}, [loading, flush]);
-
-	const [displayedValue, setDisplayedValue] = useState(value as string);
-	const [ignoreUpdates, setIgnoreUpdates] = useState(false);
+	const {loading, value, setValue} = useSettingDebounced<K>(setting);
 
 	const error = useMemo(
-		() => !validate(displayedValue).outcome,
-		[validate, displayedValue],
+		() => !validate(value as string).outcome,
+		[validate, value],
 	);
 
-	useEffect(() => {
-		if (ignoreUpdates) return;
-		setDisplayedValue((prev) => (isPending() ? prev : debouncedValue));
-	}, [ignoreUpdates, isPending, debouncedValue]);
-
-	const onChange = useMemo(() => {
-		let last = {};
-
-		const updateValue = debounce(async (current: unknown, newValue: string) => {
-			try {
-				await setValue(newValue as UserSettings[K]);
-			} finally {
-				setTimeout(() => {
-					startTransition(() => {
-						flush(); // NOTE: Fast-forward debounced state to current DB state.
-						// NOTE: Continue ignoring updates if we are not the
-						// last pending call. This works because all method
-						// calls are queued in calling order.
-						setIgnoreUpdates((prev) => (last === current ? false : prev));
-					});
-				}, TIMEOUT_INPUT_DEBOUNCE + TIMEOUT_REACTIVITY_DEBOUNCE);
-			}
-		}, TIMEOUT_INPUT_DEBOUNCE);
-
-		const _onChange = async (e) => {
-			setIgnoreUpdates(true); // NOTE: We ignore all updates.
-			const current = {};
-			last = current;
-			const newValue = sanitize(e.target.value);
-			setDisplayedValue(newValue);
-			await updateValue(current, newValue);
-			// NOTE: We will listen to updates again some timer after last update
-			// is complete.
-		};
-
-		return _onChange;
-	}, [setValue, setIgnoreUpdates]);
+	const onChange = useCallback(
+		async ({
+			target: {value},
+		}: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+			setValue(sanitize(value)),
+		[setValue, sanitize],
+	);
 
 	return (
 		<div className={className}>
@@ -110,7 +56,7 @@ const InputOneSetting = <K extends StringSettingKey>({
 			<TextField
 				disabled={loading}
 				label={label}
-				value={displayedValue}
+				value={value}
 				error={error}
 				onChange={onChange}
 			/>

--- a/imports/ui/settings/SelectColorSetting.tests.tsx
+++ b/imports/ui/settings/SelectColorSetting.tests.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import {assert} from 'chai';
+
+import {range} from '@iterable-iterator/range';
+import {map} from '@iterable-iterator/map';
+import {list} from '@iterable-iterator/list';
+
+import {faker} from '@faker-js/faker';
+
+import createUserWithPassword from '../../api/user/createUserWithPassword';
+import loginWithPassword from '../../api/user/loginWithPassword';
+import {client, randomPassword, randomUserId} from '../../_test/fixtures';
+import {render} from '../../_test/react';
+
+import {
+	TIMEOUT_INPUT_DEBOUNCE,
+	TIMEOUT_REACTIVITY_DEBOUNCE,
+} from '../constants';
+import sleep from '../../lib/async/sleep';
+
+import SelectColorSetting from './SelectColorSetting';
+
+client(__filename, () => {
+	it('should debounce user input', async () => {
+		const {setupUser} = await import('../../../test/app/client/fixtures');
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPassword(username, password);
+		await loginWithPassword(username, password);
+
+		const {findByRole} = render(
+			<SelectColorSetting aria-label="Color" setting="theme-palette-primary" />,
+		);
+
+		const button = await findByRole('button', {
+			name: 'Color',
+		});
+		const {user} = setupUser();
+
+		await user.click(button);
+		const hex = await findByRole('textbox', {name: 'hex'});
+
+		const n = 10;
+		const validInputs = list(
+			map(() => faker.color.rgb().toUpperCase(), range(n)),
+		);
+
+		// NOTE: Trigger a sequence of updates.
+		for (const validInput of validInputs) {
+			// eslint-disable-next-line no-await-in-loop
+			await sleep(5);
+			// eslint-disable-next-line no-await-in-loop
+			await user.clear(hex);
+			// eslint-disable-next-line no-await-in-loop
+			await user.paste(validInput);
+		}
+
+		assert.strictEqual(button.textContent?.toUpperCase(), validInputs.at(-1));
+
+		await sleep(TIMEOUT_INPUT_DEBOUNCE + TIMEOUT_REACTIVITY_DEBOUNCE * 2);
+
+		assert.strictEqual(button.textContent?.toUpperCase(), validInputs.at(-1));
+	}).timeout(10_000);
+});

--- a/imports/ui/settings/SelectColorSetting.tests.tsx
+++ b/imports/ui/settings/SelectColorSetting.tests.tsx
@@ -11,7 +11,7 @@ import {faker} from '@faker-js/faker';
 import createUserWithPassword from '../../api/user/createUserWithPassword';
 import loginWithPassword from '../../api/user/loginWithPassword';
 import {client, randomPassword, randomUserId} from '../../_test/fixtures';
-import {render} from '../../_test/react';
+import {render, waitFor} from '../../_test/react';
 
 import {
 	TIMEOUT_INPUT_DEBOUNCE,
@@ -20,6 +20,7 @@ import {
 import sleep from '../../lib/async/sleep';
 
 import SelectColorSetting from './SelectColorSetting';
+import {setSetting} from './hooks';
 
 client(__filename, () => {
 	it('should debounce user input', async () => {
@@ -62,4 +63,43 @@ client(__filename, () => {
 
 		assert.strictEqual(button.textContent?.toUpperCase(), validInputs.at(-1));
 	}).timeout(10_000);
+
+	it('allows to reset setting to default', async () => {
+		const {setupUser} = await import('../../../test/app/client/fixtures');
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPassword(username, password);
+		await loginWithPassword(username, password);
+
+		const {findByRole} = render(
+			<SelectColorSetting
+				aria-label="Color"
+				setting="theme-palette-secondary"
+			/>,
+		);
+
+		const button = await findByRole('button', {
+			name: 'Color',
+		});
+
+		const defaultValue = button.textContent;
+
+		const value = faker.color.rgb();
+		await setSetting('theme-palette-secondary', value);
+
+		await waitFor(() => {
+			assert.strictEqual(button.textContent, value);
+		});
+
+		const reset = await findByRole('button', {
+			name: 'Reset color',
+		});
+
+		const {user} = setupUser();
+		await user.click(reset);
+
+		await waitFor(() => {
+			assert.strictEqual(button.textContent, defaultValue);
+		});
+	});
 });

--- a/imports/ui/settings/SelectColorSetting.tsx
+++ b/imports/ui/settings/SelectColorSetting.tsx
@@ -38,7 +38,15 @@ const SelectColorSetting = <K extends SettingKey>({
 				defaultValue={value as string}
 				onChange={onChange}
 			/>
-			<SettingResetButton loading={loading} resetValue={resetValue} />
+			<SettingResetButton
+				aria-label={
+					ariaLabel === undefined
+						? undefined
+						: `Reset ${ariaLabel.toLowerCase()}`
+				}
+				loading={loading}
+				resetValue={resetValue}
+			/>
 		</div>
 	);
 };

--- a/imports/ui/settings/SelectColorSetting.tsx
+++ b/imports/ui/settings/SelectColorSetting.tsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 import ColorPicker from '../input/ColorPicker';
 import {type SettingKey, type UserSettings} from '../../api/settings';
 
-import {useSettingDebounced} from './hooks';
+import {useSettingDebounced, withBrowserCache} from './hooks';
 import SettingResetButton from './SettingResetButton';
 
 type Props<K extends SettingKey> = UserSettings[K] extends string
@@ -21,7 +21,10 @@ const SelectColorSetting = <K extends SettingKey>({
 	setting,
 	title,
 }: Props<K>) => {
-	const {loading, value, setValue, resetValue} = useSettingDebounced(setting);
+	const {loading, value, setValue, resetValue} = useSettingDebounced(
+		setting,
+		withBrowserCache,
+	);
 	const onChange = setValue as (newValue: string) => Promise<void>;
 
 	return (

--- a/imports/ui/settings/SelectColorSetting.tsx
+++ b/imports/ui/settings/SelectColorSetting.tsx
@@ -1,13 +1,11 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 
 import Typography from '@mui/material/Typography';
-
-import debounce from 'debounce';
 
 import ColorPicker from '../input/ColorPicker';
 import {type SettingKey, type UserSettings} from '../../api/settings';
 
-import {useSetting} from './hooks';
+import {useSettingDebounced} from './hooks';
 import SettingResetButton from './SettingResetButton';
 
 type Props<K extends SettingKey> = UserSettings[K] extends string
@@ -23,15 +21,8 @@ const SelectColorSetting = <K extends SettingKey>({
 	setting,
 	title,
 }: Props<K>) => {
-	const {loading, value, setValue, resetValue} = useSetting(setting);
-
-	const onChange = useMemo(
-		() =>
-			debounce(async (newValue: string) => {
-				await setValue(newValue as UserSettings[K]);
-			}, 1000),
-		[setValue],
-	);
+	const {loading, value, setValue, resetValue} = useSettingDebounced(setting);
+	const onChange = setValue as (newValue: string) => Promise<void>;
 
 	return (
 		<div className={className}>

--- a/imports/ui/settings/SelectColorSetting.tsx
+++ b/imports/ui/settings/SelectColorSetting.tsx
@@ -12,11 +12,13 @@ type Props<K extends SettingKey> = UserSettings[K] extends string
 	? {
 			className?: string;
 			title?: string;
+			'aria-label'?: string;
 			setting: K;
 	  }
 	: never;
 
 const SelectColorSetting = <K extends SettingKey>({
+	'aria-label': ariaLabel,
 	className,
 	setting,
 	title,
@@ -31,6 +33,7 @@ const SelectColorSetting = <K extends SettingKey>({
 		<div className={className}>
 			{title && <Typography variant="h4">{title}</Typography>}
 			<ColorPicker
+				aria-label={ariaLabel}
 				readOnly={loading}
 				defaultValue={value as string}
 				onChange={onChange}

--- a/imports/ui/settings/SelectColorSetting.tsx
+++ b/imports/ui/settings/SelectColorSetting.tsx
@@ -23,7 +23,7 @@ const SelectColorSetting = <K extends SettingKey>({
 	setting,
 	title,
 }: Props<K>) => {
-	const {loading, value, setValue} = useSetting(setting);
+	const {loading, value, setValue, resetValue} = useSetting(setting);
 
 	const onChange = useMemo(
 		() =>
@@ -41,7 +41,7 @@ const SelectColorSetting = <K extends SettingKey>({
 				defaultValue={value as string}
 				onChange={onChange}
 			/>
-			<SettingResetButton setting={setting} />
+			<SettingResetButton loading={loading} resetValue={resetValue} />
 		</div>
 	);
 };

--- a/imports/ui/settings/SelectColorSetting.tsx
+++ b/imports/ui/settings/SelectColorSetting.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import Typography from '@mui/material/Typography';
 
@@ -25,9 +25,13 @@ const SelectColorSetting = <K extends SettingKey>({
 }: Props<K>) => {
 	const {loading, value, setValue} = useSetting(setting);
 
-	const onChange = async (newValue: string) => {
-		await setValue(newValue as UserSettings[K]);
-	};
+	const onChange = useMemo(
+		() =>
+			debounce(async (newValue: string) => {
+				await setValue(newValue as UserSettings[K]);
+			}, 1000),
+		[setValue],
+	);
 
 	return (
 		<div className={className}>
@@ -35,7 +39,7 @@ const SelectColorSetting = <K extends SettingKey>({
 			<ColorPicker
 				readOnly={loading}
 				defaultValue={value as string}
-				onChange={debounce(onChange, 1000)}
+				onChange={onChange}
 			/>
 			<SettingResetButton setting={setting} />
 		</div>

--- a/imports/ui/settings/SettingResetButton.tsx
+++ b/imports/ui/settings/SettingResetButton.tsx
@@ -1,14 +1,17 @@
 import React, {useState} from 'react';
 
+import type Button from '@mui/material/Button';
 import LoadingButton from '@mui/lab/LoadingButton';
 import CancelIcon from '@mui/icons-material/Cancel';
+
+import type PropsOf from '../../lib/types/PropsOf';
 
 type Props = {
 	readonly loading: boolean;
 	readonly resetValue: () => Promise<void>;
-};
+} & PropsOf<typeof Button>;
 
-const SettingResetButton = ({loading, resetValue}: Props) => {
+const SettingResetButton = ({loading, resetValue, ...rest}: Props) => {
 	const [resetting, setResetting] = useState(false);
 
 	const onClick = async () => {
@@ -24,6 +27,7 @@ const SettingResetButton = ({loading, resetValue}: Props) => {
 
 	return (
 		<LoadingButton
+			{...rest}
 			disabled={loading}
 			color="secondary"
 			loading={resetting}

--- a/imports/ui/settings/SettingResetButton.tsx
+++ b/imports/ui/settings/SettingResetButton.tsx
@@ -17,9 +17,9 @@ const SettingResetButton = ({loading, resetValue}: Props) => {
 			await resetValue();
 		} catch (error: unknown) {
 			console.error(error);
+		} finally {
+			setResetting(false);
 		}
-
-		setResetting(false);
 	};
 
 	return (

--- a/imports/ui/settings/SettingResetButton.tsx
+++ b/imports/ui/settings/SettingResetButton.tsx
@@ -3,16 +3,12 @@ import React, {useState} from 'react';
 import LoadingButton from '@mui/lab/LoadingButton';
 import CancelIcon from '@mui/icons-material/Cancel';
 
-import {type SettingKey} from '../../api/settings';
-
-import {useSetting} from './hooks';
-
 type Props = {
-	readonly setting: SettingKey;
+	readonly loading: boolean;
+	readonly resetValue: () => Promise<void>;
 };
 
-const SettingResetButton = ({setting}: Props) => {
-	const {loading, resetValue} = useSetting(setting);
+const SettingResetButton = ({loading, resetValue}: Props) => {
 	const [resetting, setResetting] = useState(false);
 
 	const onClick = async () => {

--- a/imports/ui/settings/ThemePalettePrimarySetting.tests.tsx
+++ b/imports/ui/settings/ThemePalettePrimarySetting.tests.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import {assert} from 'chai';
+
+import {faker} from '@faker-js/faker';
+
+import createUserWithPassword from '../../api/user/createUserWithPassword';
+import loginWithPassword from '../../api/user/loginWithPassword';
+import {client, randomPassword, randomUserId} from '../../_test/fixtures';
+import {render, waitFor} from '../../_test/react';
+
+import {setSetting} from './hooks';
+
+import ThemePalettePrimarySetting from './ThemePalettePrimarySetting';
+
+client(__filename, () => {
+	it('loads saved value', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPassword(username, password);
+		await loginWithPassword(username, password);
+		const value = faker.color.rgb();
+		await setSetting('theme-palette-primary', value);
+
+		const {findByRole} = render(<ThemePalettePrimarySetting />);
+
+		const button = await findByRole('button', {
+			name: 'Primary color for theme',
+		});
+
+		await waitFor(() => {
+			// NOTE: Current implementation has spurious transient states.
+			assert.strictEqual(button.textContent, value);
+		});
+	});
+});

--- a/imports/ui/settings/ThemePalettePrimarySetting.tsx
+++ b/imports/ui/settings/ThemePalettePrimarySetting.tsx
@@ -9,6 +9,7 @@ type Props = {
 const ThemePaletteModeSetting = ({className}: Props) => {
 	return (
 		<SelectColorSetting
+			aria-label="Primary color for theme"
 			className={className}
 			title="Theme Primary"
 			setting="theme-palette-primary"

--- a/imports/ui/settings/ThemePaletteSecondarySetting.tests.tsx
+++ b/imports/ui/settings/ThemePaletteSecondarySetting.tests.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import {assert} from 'chai';
+
+import {faker} from '@faker-js/faker';
+
+import createUserWithPassword from '../../api/user/createUserWithPassword';
+import loginWithPassword from '../../api/user/loginWithPassword';
+import {client, randomPassword, randomUserId} from '../../_test/fixtures';
+import {render, waitFor} from '../../_test/react';
+
+import {setSetting} from './hooks';
+
+import ThemePaletteSecondarySetting from './ThemePaletteSecondarySetting';
+
+client(__filename, () => {
+	it('loads saved value', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPassword(username, password);
+		await loginWithPassword(username, password);
+		const value = faker.color.rgb();
+		await setSetting('theme-palette-secondary', value);
+
+		const {findByRole} = render(<ThemePaletteSecondarySetting />);
+
+		const button = await findByRole('button', {
+			name: 'Secondary color for theme',
+		});
+
+		await waitFor(() => {
+			// NOTE: Current implementation has spurious transient states.
+			assert.strictEqual(button.textContent, value);
+		});
+	});
+});

--- a/imports/ui/settings/ThemePaletteSecondarySetting.tsx
+++ b/imports/ui/settings/ThemePaletteSecondarySetting.tsx
@@ -9,6 +9,7 @@ type Props = {
 const ThemePaletteModeSetting = ({className}: Props) => {
 	return (
 		<SelectColorSetting
+			aria-label="Secondary color for theme"
 			className={className}
 			title="Theme Secondary"
 			setting="theme-palette-secondary"

--- a/imports/ui/settings/hooks.ts
+++ b/imports/ui/settings/hooks.ts
@@ -42,7 +42,7 @@ const defaultFilter = () => 'default';
 const userFilter = (userId: string) => `user-${userId}`;
 const userOrDefaultFilter = (userId: string | null) =>
 	userId === null ? defaultFilter() : userFilter(userId);
-const withBrowserCache = <K extends SettingKey>(
+export const withBrowserCache = <K extends SettingKey>(
 	loading: boolean,
 	userId: string | null,
 	key: K,

--- a/imports/ui/settings/hooks.ts
+++ b/imports/ui/settings/hooks.ts
@@ -177,6 +177,13 @@ export const useSettingDebounced = <K extends SettingKey>(
 				() => {
 					setClientValue(newValue);
 				},
+				// TODO: Since this is debounced, very quick logout/login
+				// cycles (as in tests) will cause the call to target whatever
+				// is the current user after the debounce timeout. We should
+				// have a way to at least pin the action to a specific user at
+				// call time. On top of that, `useSync` should gives us the
+				// ability to either `cancel` or `flush` the debounced call
+				// queue.
 				async () => setServerValue(newValue),
 			);
 	}, [sync, setClientValue, setServerValue]);
@@ -187,6 +194,13 @@ export const useSettingDebounced = <K extends SettingKey>(
 				() => {
 					setClientValue(withDefaultFn(loading, userId, key, undefined));
 				},
+				// TODO: Since this is debounced, very quick logout/login
+				// cycles (as in tests) will cause the call to target whatever
+				// is the current user after the debounce timeout. We should
+				// have a way to at least pin the action to a specific user at
+				// call time. On top of that, `useSync` should gives us the
+				// ability to either `cancel` or `flush` the debounced call
+				// queue.
 				async () => resetServerValue(),
 			);
 	}, [sync, setClientValue, setServerValue]);

--- a/imports/ui/settings/hooks.ts
+++ b/imports/ui/settings/hooks.ts
@@ -1,13 +1,4 @@
-import {
-	startTransition,
-	useCallback,
-	useEffect,
-	useMemo,
-	useState,
-} from 'react';
-
-import debounce from 'p-debounce';
-import {useDebounce} from 'use-debounce';
+import {useCallback, useMemo} from 'react';
 
 import {type SettingDocument, Settings} from '../../api/collection/settings';
 import {type UserSettings, type SettingKey, defaults} from '../../api/settings';
@@ -24,6 +15,7 @@ import {
 	TIMEOUT_INPUT_DEBOUNCE,
 	TIMEOUT_REACTIVITY_DEBOUNCE,
 } from '../constants';
+import {useSync} from '../../ux/hooks/useSync';
 
 const useSettingSubscription = <K extends SettingKey>(key: K) =>
 	useSubscription(byKey, [key]);
@@ -210,77 +202,6 @@ export const useSettingDebounced = <K extends SettingKey>(
 		value: clientValue,
 		setValue,
 		resetValue,
-	};
-};
-
-export const useSync = <T>(
-	loading: boolean,
-	serverValue: T,
-	inputDebounceTimeout: number,
-	reactivityDebounceTimeout: number,
-) => {
-	const [debouncedServerValue, {isPending, flush}] = useDebounce(
-		serverValue,
-		reactivityDebounceTimeout,
-		// NOTE: This should really be `{leading: !loading}`, but that does
-		// seem to work as `isPending` returns `true` even when leading update
-		// has been taken into account. See `flush`-based workaround below.
-		// SEE: https://github.com/xnimorz/use-debounce/issues/192
-		{leading: false},
-	);
-	useEffect(() => {
-		// NOTE: Flush when loading is done.
-		if (!loading) flush();
-	}, [loading, flush]);
-
-	const [clientValue, setClientValue] = useState(serverValue);
-	const [ignoreServer, setIgnoreServer] = useState(false);
-
-	useEffect(() => {
-		if (ignoreServer) return;
-		setClientValue((prev) => (isPending() ? prev : debouncedServerValue));
-	}, [ignoreServer, isPending, debouncedServerValue]);
-
-	const sync = useMemo(() => {
-		let last = {};
-
-		const debouncedSetServerValue = debounce(
-			async (current: unknown, setServerValue: () => Promise<void>) => {
-				try {
-					await setServerValue();
-				} finally {
-					setTimeout(() => {
-						startTransition(() => {
-							flush(); // NOTE: Fast-forward debounced state to current DB state.
-							// NOTE: Continue ignoring updates if we are not the
-							// last pending call. This works because all method
-							// calls are queued in calling order.
-							setIgnoreServer((prev) => (last === current ? false : prev));
-						});
-					}, inputDebounceTimeout + reactivityDebounceTimeout);
-				}
-			},
-			inputDebounceTimeout,
-		);
-
-		return async (
-			setClientValue: () => void,
-			setServerValue: () => Promise<void>,
-		) => {
-			setIgnoreServer(true); // NOTE: We ignore all updates.
-			const current = {};
-			last = current;
-			setClientValue();
-			await debouncedSetServerValue(current, setServerValue);
-			// NOTE: We will listen to updates again some time after last update
-			// is complete.
-		};
-	}, [setIgnoreServer, flush, inputDebounceTimeout, reactivityDebounceTimeout]);
-
-	return {
-		value: clientValue,
-		setValue: setClientValue,
-		sync,
 	};
 };
 

--- a/imports/ux/hooks/useSync.tests.ts
+++ b/imports/ux/hooks/useSync.tests.ts
@@ -1,0 +1,174 @@
+import {assert} from 'chai';
+
+import {renderHook, waitFor} from '../../_test/react';
+import {client} from '../../_test/fixtures';
+
+import sleep from '../../lib/async/sleep';
+
+import {useSync} from './useSync';
+
+client(__filename, () => {
+	it('client value is identical to server value on init when loading = false', async () => {
+		const serverValue = {};
+
+		const {
+			result: {
+				current: {value: clientValue},
+			},
+		} = renderHook(
+			({
+				loading,
+				serverValue,
+				inputDebounceTimeout,
+				reactivityDebounceTimeout,
+			}) =>
+				useSync(
+					loading,
+					serverValue,
+					inputDebounceTimeout,
+					reactivityDebounceTimeout,
+				),
+			{
+				initialProps: {
+					loading: false,
+					serverValue,
+					inputDebounceTimeout: 0,
+					reactivityDebounceTimeout: 0,
+				},
+			},
+		);
+
+		assert.strictEqual(clientValue, serverValue);
+	});
+
+	it('client value is identical to server value on init when loading = true', async () => {
+		const serverValue = {};
+
+		const {
+			result: {
+				current: {value: clientValue},
+			},
+		} = renderHook(
+			({
+				loading,
+				serverValue,
+				inputDebounceTimeout,
+				reactivityDebounceTimeout,
+			}) =>
+				useSync(
+					loading,
+					serverValue,
+					inputDebounceTimeout,
+					reactivityDebounceTimeout,
+				),
+			{
+				initialProps: {
+					loading: false,
+					serverValue,
+					inputDebounceTimeout: 0,
+					reactivityDebounceTimeout: 0,
+				},
+			},
+		);
+
+		assert.strictEqual(clientValue, serverValue);
+	});
+
+	it('server value updates are taken into account', async () => {
+		const serverValueA = 'A';
+
+		const {result, rerender} = renderHook(
+			({
+				loading,
+				serverValue,
+				inputDebounceTimeout,
+				reactivityDebounceTimeout,
+			}) =>
+				useSync(
+					loading,
+					serverValue,
+					inputDebounceTimeout,
+					reactivityDebounceTimeout,
+				),
+			{
+				initialProps: {
+					loading: false,
+					serverValue: serverValueA,
+					inputDebounceTimeout: 0,
+					reactivityDebounceTimeout: 100,
+				},
+			},
+		);
+
+		assert.strictEqual(result.current.value, serverValueA);
+
+		const serverValueB = 'B';
+
+		rerender({
+			loading: false,
+			serverValue: serverValueB,
+			inputDebounceTimeout: 0,
+			reactivityDebounceTimeout: 100,
+		});
+
+		await waitFor(() => {
+			assert.strictEqual(result.current.value, serverValueB);
+		});
+	});
+
+	it('server value updates are debounced', async () => {
+		const initialValue = 0;
+
+		const {result, rerender} = renderHook(
+			({
+				loading,
+				serverValue,
+				inputDebounceTimeout,
+				reactivityDebounceTimeout,
+			}) =>
+				useSync(
+					loading,
+					serverValue,
+					inputDebounceTimeout,
+					reactivityDebounceTimeout,
+				),
+			{
+				initialProps: {
+					loading: false,
+					serverValue: initialValue,
+					inputDebounceTimeout: 0,
+					reactivityDebounceTimeout: 100,
+				},
+			},
+		);
+
+		assert.strictEqual(result.current.value, initialValue);
+
+		let currentValue = initialValue;
+
+		for (let i = 0; i < 10; ++i) {
+			// eslint-disable-next-line no-await-in-loop
+			await sleep(20);
+			rerender({
+				loading: false,
+				serverValue: ++currentValue,
+				inputDebounceTimeout: 0,
+				reactivityDebounceTimeout: 100,
+			});
+		}
+
+		const observedValues = new Set();
+
+		await waitFor(() => {
+			const {
+				current: {value},
+			} = result;
+			observedValues.add(value);
+			assert.strictEqual(value, currentValue);
+		});
+
+		assert.deepEqual(observedValues, new Set([0, currentValue]));
+	});
+
+	// TODO: Test toggling from `loading` to `!loading`.
+});

--- a/imports/ux/hooks/useSync.tests.ts
+++ b/imports/ux/hooks/useSync.tests.ts
@@ -1,14 +1,22 @@
 import {assert} from 'chai';
 
+import {useMemo} from 'react';
+
+import {list} from '@iterable-iterator/list';
+import {nrepeat} from '@iterable-iterator/repeat';
+import {filter} from '@iterable-iterator/filter';
+
 import {renderHook, waitFor} from '../../_test/react';
 import {client} from '../../_test/fixtures';
 
 import sleep from '../../lib/async/sleep';
 
+import {AsyncQueue} from '../../lib/async/queue';
+
 import {useSync} from './useSync';
 
 client(__filename, () => {
-	it('client value is identical to server value on init when loading = false', async () => {
+	it('should have client value identical to server value on init when loading = false', async () => {
 		const serverValue = {};
 
 		const {
@@ -41,7 +49,7 @@ client(__filename, () => {
 		assert.strictEqual(clientValue, serverValue);
 	});
 
-	it('client value is identical to server value on init when loading = true', async () => {
+	it('should have client value identical to server value on init when loading = true', async () => {
 		const serverValue = {};
 
 		const {
@@ -74,7 +82,7 @@ client(__filename, () => {
 		assert.strictEqual(clientValue, serverValue);
 	});
 
-	it('server value updates are taken into account', async () => {
+	it('should take server updates into account', async () => {
 		const serverValueA = 'A';
 
 		const {result, rerender} = renderHook(
@@ -116,7 +124,7 @@ client(__filename, () => {
 		});
 	});
 
-	it('server value updates are debounced', async () => {
+	it('should debounce server updates', async () => {
 		const initialValue = 0;
 
 		const {result, rerender} = renderHook(
@@ -170,5 +178,181 @@ client(__filename, () => {
 		assert.deepEqual(observedValues, new Set([0, currentValue]));
 	});
 
-	// TODO: Test toggling from `loading` to `!loading`.
+	it('should take loaded server value into account immediately', async () => {
+		const serverValueA = 'A';
+
+		const {result, rerender} = renderHook(
+			({
+				loading,
+				serverValue,
+				inputDebounceTimeout,
+				reactivityDebounceTimeout,
+			}) =>
+				useSync(
+					loading,
+					serverValue,
+					inputDebounceTimeout,
+					reactivityDebounceTimeout,
+				),
+			{
+				initialProps: {
+					loading: true,
+					serverValue: serverValueA,
+					inputDebounceTimeout: 0,
+					reactivityDebounceTimeout: 1000,
+				},
+			},
+		);
+
+		assert.strictEqual(result.current.value, serverValueA);
+
+		const serverValueB = 'B';
+
+		rerender({
+			loading: false,
+			serverValue: serverValueB,
+			inputDebounceTimeout: 0,
+			reactivityDebounceTimeout: 1000,
+		});
+
+		assert.strictEqual(result.current.value, serverValueB);
+	});
+
+	it('should debounce client updates', async () => {
+		const inputDebounceTimeout = 0;
+		const reactivityDebounceTimeout = 1000;
+		const serverValueSequence = 'ABCDEFGHIJ';
+		const queue = new AsyncQueue();
+		const setServerValue = async (newValue: string) => {
+			queue.enqueue(async () => sleep(10)); // NOTE: Simulates sending.
+			queue.enqueue(async () => sleep(30)); // NOTE: Simulates receiving.
+			queue.enqueue(() => {
+				rerender({
+					loading: false,
+					serverValue: newValue,
+					inputDebounceTimeout,
+					reactivityDebounceTimeout,
+				});
+			});
+			// NOTE: A real setter cannot await feedback so we do not.
+		};
+
+		const {result, rerender} = renderHook(
+			({
+				loading,
+				serverValue,
+				inputDebounceTimeout,
+				reactivityDebounceTimeout,
+			}) => {
+				const {
+					value: clientValue,
+					setValue: setClientValue,
+					sync,
+				} = useSync(
+					loading,
+					serverValue,
+					inputDebounceTimeout,
+					reactivityDebounceTimeout,
+				);
+
+				const setValue = useMemo(() => {
+					return async (newValue: string) =>
+						sync(
+							() => {
+								setClientValue(newValue);
+							},
+							async () => setServerValue(newValue),
+						);
+				}, [sync, setClientValue, setServerValue]);
+
+				return {
+					clientValue,
+					serverValue,
+					setValue,
+				};
+			},
+			{
+				initialProps: {
+					loading: false,
+					serverValue: serverValueSequence[0]!,
+					inputDebounceTimeout,
+					reactivityDebounceTimeout,
+				},
+			},
+		);
+
+		// NOTE: Check initial value is correct.
+		assert.strictEqual(result.current.clientValue, serverValueSequence[0]!);
+
+		// NOTE: Trigger a sequence of updates.
+		for (const newValue of serverValueSequence.slice(1)) {
+			// eslint-disable-next-line no-await-in-loop
+			await sleep(5);
+			// NOTE: This is how `setValue` would be used in an `onChange`
+			// handler.
+			void result.current.setValue(newValue);
+		}
+
+		type Target = {name: string; values: string[]};
+		const observed: {server: Target; client: Target} = {
+			server: {
+				name: 'server',
+				values: [],
+			},
+			client: {
+				name: 'client',
+				values: [],
+			},
+		};
+
+		const observe = (target: Target, value: string) => {
+			if (value !== target.values.at(-1)) {
+				target.values.push(value);
+			}
+		};
+
+		await waitFor(() => {
+			const {
+				current: {clientValue, serverValue},
+			} = result;
+			observe(observed.server, serverValue);
+			// TODO: Last update should happen almost instantly. Should be
+			// instantly.
+			assert.strictEqual(clientValue, serverValueSequence.at(-1));
+		});
+
+		await waitFor(
+			() => {
+				const {
+					current: {clientValue, serverValue},
+				} = result;
+				observe(observed.client, clientValue);
+				observe(observed.server, serverValue);
+				assert.strictEqual(serverValue, serverValueSequence.at(-1));
+			},
+			{timeout: inputDebounceTimeout + reactivityDebounceTimeout * 2},
+		);
+
+		assert.isAtLeast(observed.client.values.length, 1);
+		assert.isAtLeast(observed.server.values.length, 1);
+
+		assert.deepEqual(observed.client, {
+			name: 'client',
+			values: list(
+				nrepeat(serverValueSequence.at(-1), observed.client.values.length),
+			),
+		});
+
+		const _observedServerValues = new Set(observed.server.values);
+
+		assert.deepEqual(observed.server, {
+			name: 'server',
+			values: list(
+				filter(
+					(value: string) => _observedServerValues.has(value),
+					serverValueSequence,
+				),
+			),
+		});
+	});
 });

--- a/imports/ux/hooks/useSync.ts
+++ b/imports/ux/hooks/useSync.ts
@@ -1,0 +1,75 @@
+import {startTransition, useEffect, useMemo, useState} from 'react';
+
+import debounce from 'p-debounce';
+import {useDebounce} from 'use-debounce';
+
+export const useSync = <T>(
+	loading: boolean,
+	serverValue: T,
+	inputDebounceTimeout: number,
+	reactivityDebounceTimeout: number,
+) => {
+	const [debouncedServerValue, {isPending, flush}] = useDebounce(
+		serverValue,
+		reactivityDebounceTimeout,
+		// NOTE: This should really be `{leading: !loading}`, but that does
+		// seem to work as `isPending` returns `true` even when leading update
+		// has been taken into account. See `flush`-based workaround below.
+		// SEE: https://github.com/xnimorz/use-debounce/issues/192
+		{leading: false},
+	);
+	useEffect(() => {
+		// NOTE: Flush when loading is done.
+		if (!loading) flush();
+	}, [loading, flush]);
+
+	const [clientValue, setClientValue] = useState(serverValue);
+	const [ignoreServer, setIgnoreServer] = useState(false);
+
+	useEffect(() => {
+		if (ignoreServer) return;
+		setClientValue((prev) => (isPending() ? prev : debouncedServerValue));
+	}, [ignoreServer, isPending, debouncedServerValue]);
+
+	const sync = useMemo(() => {
+		let last = {};
+
+		const debouncedSetServerValue = debounce(
+			async (current: unknown, setServerValue: () => Promise<void>) => {
+				try {
+					await setServerValue();
+				} finally {
+					setTimeout(() => {
+						startTransition(() => {
+							flush(); // NOTE: Fast-forward debounced state to current DB state.
+							// NOTE: Continue ignoring updates if we are not the
+							// last pending call. This works because all method
+							// calls are queued in calling order.
+							setIgnoreServer((prev) => (last === current ? false : prev));
+						});
+					}, inputDebounceTimeout + reactivityDebounceTimeout);
+				}
+			},
+			inputDebounceTimeout,
+		);
+
+		return async (
+			setClientValue: () => void,
+			setServerValue: () => Promise<void>,
+		) => {
+			setIgnoreServer(true); // NOTE: We ignore all updates.
+			const current = {};
+			last = current;
+			setClientValue();
+			await debouncedSetServerValue(current, setServerValue);
+			// NOTE: We will listen to updates again some time after last update
+			// is complete.
+		};
+	}, [setIgnoreServer, flush, inputDebounceTimeout, reactivityDebounceTimeout]);
+
+	return {
+		value: clientValue,
+		setValue: setClientValue,
+		sync,
+	};
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13034,6 +13034,11 @@
       "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true
     },
+    "p-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-debounce/-/p-debounce-4.0.0.tgz",
+      "integrity": "sha512-4Ispi9I9qYGO4lueiLDhe4q4iK5ERK8reLsuzH6BPaXn53EGaua8H66PXIFGrW897hwjXp+pVLrm/DLxN0RF0A=="
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16926,9 +16926,9 @@
       "dev": true
     },
     "use-debounce": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.1.tgz",
-      "integrity": "sha512-0uUXjOfm44e6z4LZ/woZvkM8FwV1wiuoB6xnrrOmeAEjRDDzTLQNRFtYHvqUsJdrz1X37j0rVGIVp144GLHGKg=="
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.4.tgz",
+      "integrity": "sha512-6Cf7Yr7Wk7Kdv77nnJMf6de4HuDE4dTxKij+RqE9rufDsI6zsbjyAxcH5y2ueJCQAnfgKbzXbZHYlkFwmBlWkw=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "meteor-node-stubs": "^1.2.5",
     "node-fetch": "^3.3.2",
     "notistack": "^3.0.1",
+    "p-debounce": "^4.0.0",
     "papaparse": "^5.4.1",
     "pdfjs-dist": "~3.4.120",
     "qrcode.react": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "sharp": "^0.33.0",
     "sort-keys": "^5.0.0",
     "tss-react": "^4.9.1",
-    "use-debounce": "^10.0.0",
+    "use-debounce": "^10.0.4",
     "xml-js": "^1.6.11",
     "zod": "^3.22.4"
   },

--- a/test/app/client/fixtures.ts
+++ b/test/app/client/fixtures.ts
@@ -63,9 +63,9 @@ export const fillIn = async (
 const flakyCloseModals = async ({user}: {user: UserEvent}) => {
 	// This is to escape any modals that have been opened by previous tests.
 	// TODO find way to do this in cleanup hook
-	await user.keyboard('[Escape]');
-	await user.keyboard('[Escape]');
-	await user.keyboard('[Escape]');
+	await user.keyboard('{Escape}');
+	await user.keyboard('{Escape}');
+	await user.keyboard('{Escape}');
 };
 
 export const createUserWithPasswordAndLogin = async (

--- a/test/app/client/fixtures.ts
+++ b/test/app/client/fixtures.ts
@@ -14,13 +14,15 @@ configure({
 
 type UserEvent = ReturnType<typeof userEvent.setup>;
 
-export type App = {
+export type User = {
 	user: UserEvent;
 	userWithoutPointerEventsCheck: UserEvent;
 	userWithRealisticTypingSpeed: UserEvent;
-} & BoundFunctions<typeof queries>;
+};
 
-export const setupApp = (): App => {
+export type App = User & BoundFunctions<typeof queries>;
+
+export const setupUser = () => {
 	const user = userEvent.setup();
 	return {
 		user,
@@ -30,6 +32,12 @@ export const setupApp = (): App => {
 		userWithRealisticTypingSpeed: user.setup({
 			delay: 100,
 		}),
+	};
+};
+
+export const setupApp = (): App => {
+	return {
+		...setupUser(),
 		...getQueriesForElement(document.body),
 	};
 };

--- a/test/app/client/patient/personal-information.app-tests.ts
+++ b/test/app/client/patient/personal-information.app-tests.ts
@@ -127,7 +127,7 @@ const editPatient = async (
 	if (Array.isArray(allergies)) {
 		await userWithRealisticTypingSpeed.type(
 			await findByRole('textbox', {name: 'Allergies'}),
-			allergies.join('[Enter]') + '[Enter]',
+			allergies.join('{Enter}') + '{Enter}',
 		);
 	}
 
@@ -154,21 +154,21 @@ const editPatient = async (
 	if (Array.isArray(phone)) {
 		await userWithRealisticTypingSpeed.type(
 			await findByRole('textbox', {name: 'Numéro de téléphone'}),
-			phone.join('[Enter]') + '[Enter]',
+			phone.join('{Enter}') + '{Enter}',
 		);
 	}
 
 	if (Array.isArray(doctors)) {
 		await userWithRealisticTypingSpeed.type(
 			await findByRole('textbox', {name: 'Médecin Traitant'}),
-			doctors.join('[Enter]') + '[Enter]',
+			doctors.join('{Enter}') + '{Enter}',
 		);
 	}
 
 	if (Array.isArray(insurances)) {
 		await userWithRealisticTypingSpeed.type(
 			await findByRole('textbox', {name: 'Mutuelle'}),
-			insurances.join('[Enter]') + '[Enter]',
+			insurances.join('{Enter}') + '{Enter}',
 		);
 	}
 


### PR DESCRIPTION
Bounciness is inevitable given we are firing lots of asynchronous updates without having a reliable way to tell which state updates come from us and which come from others, and with a delay between update completion and update result feedback.

Maybe Meteor had some logic to improve those kind of situations that we got rid of by bypassing their implementation of `observeChanges` etc. (optimistic updates)? Or has it just been exacerbated since Meteor went `async`?

We did our best with this PR to at least get an acceptable UX. We will look into solving this canonically later, since, at the moment, it is only really a problem for two inputs in settings, and the theme and allergy color pickers (inputs that enable the user to fire many concurrent updates).

- Fixes #1130.

The next step would be to use CRDTs to store values in the database and be able to merge concurrent updates. For single values, this can be minimal (e.g. an update counter that wraps `serverTick >= clientTick || clientTick - serverTick >= OVERFLOW_THRESHOLD`). For others, might want to look at alternatives listed at:
- https://github.com/infoderm/patients/issues/276#issuecomment-2056823815