### PR TITLE
Improve and allow to configure paid synchronization in `<ConsultationEditor>`

### DIFF
--- a/imports/api/collection/consultations.ts
+++ b/imports/api/collection/consultations.ts
@@ -2,6 +2,14 @@ import schema from '../../util/schema';
 
 import define from './define';
 
+export const paymentMethod = schema.union([
+	schema.literal('cash'),
+	schema.literal('wire'),
+	schema.literal('third-party'),
+]);
+
+export type PaymentMethod = schema.infer<typeof paymentMethod>;
+
 export const consultationFields = schema
 	.object({
 		patientId: schema.string(),
@@ -22,7 +30,7 @@ export const consultationFields = schema
 		unpaid: schema.boolean().optional(),
 		book: schema.string().optional(),
 		inBookNumber: schema.number().int().gte(1).optional(),
-		payment_method: schema.string().optional(),
+		payment_method: paymentMethod.optional(),
 		isCancelled: schema.boolean().optional(),
 		cancellationDatetime: schema.date().optional(),
 		cancellationReason: schema.string().optional(),

--- a/imports/api/consultations.ts
+++ b/imports/api/consultations.ts
@@ -14,6 +14,7 @@ import {
 	type ConsultationDocument,
 	type ConsultationFields,
 	Consultations,
+	paymentMethod,
 } from './collection/consultations';
 import {key as statsKey} from './collection/consultations/stats';
 import type TransactionDriver from './transaction/TransactionDriver';
@@ -250,12 +251,7 @@ const sanitizeUpdate = function* (
 		schema.string(),
 		(book: string | undefined | null) => books.sanitize(book ?? ''),
 	);
-	yield* yieldResettableKey(
-		fields,
-		'payment_method',
-		schema.string(),
-		(x) => x,
-	);
+	yield* yieldResettableKey(fields, 'payment_method', paymentMethod, (x) => x);
 
 	yield* yieldResettableKey(
 		fields,

--- a/imports/api/settings.ts
+++ b/imports/api/settings.ts
@@ -10,6 +10,8 @@ import type ModuloWeekInterval from '../ui/settings/ModuloWeekInterval';
 import {Settings} from './collection/settings';
 import findOneSync from './publication/findOneSync';
 
+import {type PaymentMethod} from './collection/consultations';
+
 export type UserSettings = {
 	'theme-palette-mode': PaletteMode;
 	'theme-palette-primary': string;
@@ -29,6 +31,7 @@ export type UserSettings = {
 	iban: string;
 	'account-holder': string;
 	'displayed-week-days': WeekDay[];
+	'consultations-paid-sync': PaymentMethod[];
 };
 
 export type SettingKey = keyof UserSettings;
@@ -52,6 +55,7 @@ export const defaults: UserSettings = {
 	iban: '',
 	'account-holder': '',
 	'displayed-week-days': [...ALL_WEEK_DAYS],
+	'consultations-paid-sync': [],
 };
 
 export function get(owner: string, key: string) {

--- a/imports/ui/consultations/ConsultationEditor.tests.tsx
+++ b/imports/ui/consultations/ConsultationEditor.tests.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import {BrowserRouter} from 'react-router-dom';
+
+import {client, randomPassword, randomUserId} from '../../_test/fixtures';
+import {render as _render} from '../../_test/react';
+import createUserWithPasswordAndLogin from '../../api/user/createUserWithPasswordAndLogin';
+
+import {newConsultationFormData} from '../../api/_dev/populate/consultations';
+import DateTimeLocalizationProvider from '../i18n/DateTimeLocalizationProvider';
+
+import ConsultationEditor from './ConsultationEditor';
+
+const render = (children: React.ReactNode) =>
+	_render(children, {
+		wrapper: ({children}: {children: React.ReactNode}) => (
+			<DateTimeLocalizationProvider>
+				<BrowserRouter>{children}</BrowserRouter>
+			</DateTimeLocalizationProvider>
+		),
+	});
+
+client(__filename, () => {
+	it('should render when loading', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPasswordAndLogin(username, password);
+
+		const {findByRole} = render(
+			<ConsultationEditor loading found={false} consultation={undefined} />,
+		);
+
+		await findByRole('generic', {name: 'loading'});
+	});
+
+	it('should render if not found', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPasswordAndLogin(username, password);
+
+		const {findByRole} = render(
+			<ConsultationEditor
+				loading={false}
+				found={false}
+				consultation={undefined}
+			/>,
+		);
+
+		await findByRole('heading', {name: 'Consultation not found.'});
+	});
+
+	it('should render loading state before beginning consultation', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPasswordAndLogin(username, password);
+
+		const consultation = {
+			...newConsultationFormData(),
+		};
+
+		const {findByRole} = render(
+			<ConsultationEditor found loading={false} consultation={consultation} />,
+		);
+
+		await findByRole('generic', {name: 'loading'});
+	});
+
+	it('should render when loaded and found', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPasswordAndLogin(username, password);
+
+		const consultation = {
+			...newConsultationFormData(),
+			isDone: true,
+		};
+
+		const {findByRole} = render(
+			<ConsultationEditor found loading={false} consultation={consultation} />,
+		);
+
+		await findByRole('textbox', {name: 'Motif de la visite'});
+	});
+});

--- a/imports/ui/consultations/ConsultationEditor.tsx
+++ b/imports/ui/consultations/ConsultationEditor.tsx
@@ -36,6 +36,7 @@ import ConsultationForm from './ConsultationForm';
 import PrecedingConsultationsList from './PrecedingConsultationsList';
 import useNextInBookNumber from './useNextInBookNumber';
 import useConsultationEditorState, {
+	PriceStatus,
 	type ConsultationEditorInit,
 	type reducer,
 	type State,
@@ -124,13 +125,7 @@ const ConsultationEditor = ({consultation}: ConsultationEditorProps) => {
 
 			inBookNumberString,
 		},
-		config: {
-			dirty,
-			saving,
-			lastSaveWasSuccessful,
-			lastInsertedId,
-			priceWarning,
-		},
+		config: {dirty, saving, lastSaveWasSuccessful, lastInsertedId, priceStatus},
 	} = state;
 
 	usePrompt(
@@ -177,11 +172,15 @@ const ConsultationEditor = ({consultation}: ConsultationEditorProps) => {
 		});
 
 		if (
-			priceWarning &&
+			priceStatus !== PriceStatus.OK &&
 			!(await dialog((resolve) => (
 				<ConfirmationDialog
 					title="Confirm"
-					text={`This consultation has a price of ${priceString}.`}
+					text={
+						priceStatus === PriceStatus.SHOULD_NOT_BE_EMPTY
+							? "This consultation's price is not set."
+							: `This consultation has a price of ${priceString}.`
+					}
 					cancel="Cancel"
 					confirm={
 						consultationId === undefined

--- a/imports/ui/consultations/ConsultationEditorHeader.tsx
+++ b/imports/ui/consultations/ConsultationEditorHeader.tsx
@@ -13,7 +13,24 @@ import CopiableTextField from '../input/CopiableTextField';
 
 import usePatient from '../patients/usePatient';
 
-const ConsultationEditorHeader = ({consultation, state, update}) => {
+import {
+	type ConsultationEditorInit,
+	type State,
+} from './useConsultationEditorState';
+
+type Props = {
+	readonly consultation: ConsultationEditorInit;
+	readonly state: State;
+	readonly update: (
+		key: keyof State['fields'],
+	) => (event: {target: {value: Date | null}}) => void;
+};
+
+const ConsultationEditorHeader = ({
+	consultation,
+	state: {fields},
+	update,
+}: Props) => {
 	const patientId = consultation.patientId;
 
 	const init = {};
@@ -30,7 +47,7 @@ const ConsultationEditorHeader = ({consultation, state, update}) => {
 
 	const {loading, fields: patient} = usePatient(init, query, deps);
 
-	const {datetime, doneDatetime} = state;
+	const {datetime, doneDatetime} = fields;
 
 	const textPlaceHolder = loading ? '' : '?';
 

--- a/imports/ui/consultations/ConsultationForm.tsx
+++ b/imports/ui/consultations/ConsultationForm.tsx
@@ -1,7 +1,6 @@
 import React, {useState} from 'react';
 import {styled} from '@mui/material/styles';
 
-import dateParseISO from 'date-fns/parseISO';
 import getYear from 'date-fns/getYear';
 
 import Grid from '@mui/material/Grid';
@@ -27,6 +26,8 @@ import makeSubstringSuggestions from '../input/makeSubstringSuggestions';
 import CurrencyAmountInput from '../input/CurrencyAmountInput';
 import {parsePositiveIntegerStrictOrUndefined} from '../../api/string';
 import useBooksFind from '../books/useBooksFind';
+
+import {type State} from './useConsultationEditorState';
 
 const useInBookNumberCollides = (
 	consultationId: string | undefined,
@@ -56,61 +57,18 @@ const TextArea = styled(TextField)(() => ({
 	width: '100%',
 }));
 
-const defaultDate = '1970-01-01';
-const defaultTime = '00:00';
-
-const datetimeParse = (date, time) => dateParseISO(`${date}T${time}:00`);
-
-export const defaultState = {
-	_id: undefined,
-	datetime: datetimeParse(defaultDate, defaultTime),
-	doneDatetime: undefined,
-	reason: '',
-	done: '',
-	todo: '',
-	treatment: '',
-	next: '',
-	more: '',
-
-	currency: 'EUR',
-	payment_method: 'cash',
-	priceString: '',
-	paidString: '',
-	book: '',
-	inBookNumberString: '',
-
-	syncPaid: true,
-	syncInBookNumber: false,
-	loadingInBookNumber: false,
-	priceWarning: false,
-	priceError: true,
-	paidError: true,
-	inBookNumberError: true,
-	inBookNumberDisabled: false,
-	dirty: false,
-	saving: false,
-	lastSaveWasSuccessful: false,
-	lastInsertedId: undefined,
-};
-
-export type State = Omit<
-	typeof defaultState,
-	'_id' | 'doneDatetime' | 'lastInsertedId'
-> & {
-	_id?: string;
-	doneDatetime?: Date;
-	lastInsertedId?: string;
-};
-
 type Props = {
-	readonly consultation: State;
+	readonly state: State;
 	readonly update?: (
 		key: string,
 		transform?: (x: any) => any,
 	) => (event: {target: {value: any}}) => void;
 };
 
-const ConsultationForm = ({consultation, update}: Props) => {
+const ConsultationForm = ({
+	state: {fields: consultation, config},
+	update,
+}: Props) => {
 	const {
 		_id,
 		datetime,
@@ -128,7 +86,9 @@ const ConsultationForm = ({consultation, update}: Props) => {
 		priceString,
 		paidString,
 		book,
+	} = consultation;
 
+	const {
 		syncInBookNumber,
 		loadingInBookNumber,
 		syncPaid,
@@ -137,7 +97,7 @@ const ConsultationForm = ({consultation, update}: Props) => {
 		priceWarning,
 		priceError,
 		paidError,
-	} = consultation;
+	} = config;
 
 	// eslint-disable-next-line react/hook-use-state
 	const [initialDatetime] = useState(datetime);

--- a/imports/ui/consultations/NewConsultation.tsx
+++ b/imports/ui/consultations/NewConsultation.tsx
@@ -34,7 +34,7 @@ const NewConsultation = () => {
 		currency: 'EUR',
 		payment_method: 'cash',
 		book: bookNumber,
-	};
+	} as const;
 
 	return (
 		<ConsultationEditor found loading={false} consultation={consultation} />

--- a/imports/ui/consultations/PaidConsultationsList.tests.tsx
+++ b/imports/ui/consultations/PaidConsultationsList.tests.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import {BrowserRouter} from 'react-router-dom';
+
+import dateFormat from 'date-fns/format';
+import startOfYear from 'date-fns/startOfYear';
+import subYears from 'date-fns/subYears';
+
+import {client, randomPassword, randomUserId} from '../../_test/fixtures';
+import {render as _render} from '../../_test/react';
+import createUserWithPasswordAndLogin from '../../api/user/createUserWithPasswordAndLogin';
+import insertConsultation from '../../api/endpoint/consultations/insert';
+import {newConsultationFormData} from '../../api/_dev/populate/consultations';
+import call from '../../api/endpoint/call';
+
+import DateTimeLocalizationProvider from '../i18n/DateTimeLocalizationProvider';
+
+import insertPatient from '../../api/endpoint/patients/insert';
+import {newPatientFormData} from '../../api/_dev/populate/patients';
+
+import PaidConsultationsList from './PaidConsultationsList';
+
+const render = (children: React.ReactNode) =>
+	_render(children, {
+		wrapper: ({children}: {children: React.ReactNode}) => (
+			<DateTimeLocalizationProvider>
+				<BrowserRouter>{children}</BrowserRouter>
+			</DateTimeLocalizationProvider>
+		),
+	});
+
+client(__filename, () => {
+	it('should render when empty', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPasswordAndLogin(username, password);
+
+		const now = new Date();
+		const currentYear = startOfYear(now);
+		const previousYear = subYears(currentYear, 1);
+
+		const {findByRole} = render(
+			<PaidConsultationsList
+				year={Number.parseInt(dateFormat(currentYear, 'y'), 10)}
+			/>,
+		);
+
+		await findByRole('link', {name: dateFormat(previousYear, 'y')});
+	});
+
+	it('should render paid consultation', async () => {
+		const username = randomUserId();
+		const password = randomPassword();
+		await createUserWithPasswordAndLogin(username, password);
+
+		const now = new Date();
+		const currentYear = startOfYear(now);
+
+		const {findByRole} = render(
+			<PaidConsultationsList
+				year={Number.parseInt(dateFormat(currentYear, 'y'), 10)}
+			/>,
+		);
+
+		const patientFields = newPatientFormData();
+
+		const patientId = await call(insertPatient, patientFields);
+
+		await call(
+			insertConsultation,
+			newConsultationFormData({
+				patientId,
+				price: 70,
+				paid: 70,
+				datetime: now,
+			}),
+		);
+
+		const {firstname, lastname} = patientFields;
+
+		await findByRole('link', {name: `${lastname} ${firstname}`});
+	});
+});

--- a/imports/ui/consultations/PaidConsultationsList.tsx
+++ b/imports/ui/consultations/PaidConsultationsList.tsx
@@ -11,7 +11,10 @@ import {capitalized} from '../../api/string';
 import Center from '../grid/Center';
 import YearJumper from '../navigation/YearJumper';
 import type Filter from '../../api/query/Filter';
-import {type ConsultationDocument} from '../../api/collection/consultations';
+import {
+	type PaymentMethod,
+	type ConsultationDocument,
+} from '../../api/collection/consultations';
 import FixedFab from '../button/FixedFab';
 
 import ConsultationsStatsCard from './ConsultationsStatsCard';
@@ -19,7 +22,7 @@ import ConsultationsPager from './ConsultationsPager';
 
 type Props = {
 	readonly year: number;
-	readonly payment_method?: string;
+	readonly payment_method?: PaymentMethod;
 };
 
 const PaidConsultationsList = ({year, payment_method = undefined}: Props) => {

--- a/imports/ui/consultations/useConsultationEditorState.ts
+++ b/imports/ui/consultations/useConsultationEditorState.ts
@@ -234,8 +234,7 @@ export type Action =
 	| {type: 'loading-next-in-book-number'}
 	| {type: 'disable-in-book-number'}
 	| {type: 'save'}
-	| {type: 'save-failure'}
-	| {type: 'not-dirty'};
+	| {type: 'save-failure'};
 
 export const reducer = ({fields, config}: State, action: Action): State => {
 	switch (action.type) {
@@ -428,16 +427,6 @@ export const reducer = ({fields, config}: State, action: Action): State => {
 					...config,
 					saving: false,
 					lastSaveWasSuccessful: false,
-				},
-			};
-		}
-
-		case 'not-dirty': {
-			return {
-				fields,
-				config: {
-					...config,
-					dirty: false,
 				},
 			};
 		}

--- a/imports/ui/consultations/useConsultationEditorState.ts
+++ b/imports/ui/consultations/useConsultationEditorState.ts
@@ -1,0 +1,467 @@
+import {useEffect, useReducer} from 'react';
+
+import dateParseISO from 'date-fns/parseISO';
+
+import {type PaymentMethod} from '../../api/collection/consultations';
+import {type ConsultationDocument} from '../../api/collection/consultations';
+import {books} from '../../api/books';
+import removeUndefined from '../../util/object/removeUndefined';
+import {useSetting} from '../settings/hooks';
+
+export type ConsultationEditorInit = Pick<
+	ConsultationDocument,
+	| 'isDone'
+	| 'patientId'
+	| 'datetime'
+	| 'doneDatetime'
+	| 'reason'
+	| 'done'
+	| 'todo'
+	| 'treatment'
+	| 'next'
+	| 'more'
+	| 'currency'
+	| 'payment_method'
+	| 'price'
+	| 'paid'
+	| 'book'
+	| 'inBookNumber'
+> &
+	Partial<Pick<ConsultationDocument, '_id'>>;
+
+const useConsultationEditorState = (consultation: ConsultationEditorInit) => {
+	const {loading, value} = useSetting('consultations-paid-sync');
+	const [state, dispatch] = useReducer(
+		reducer,
+		{...consultation, syncPaidPaymentMethods: value},
+		init,
+	);
+	useEffect(() => {
+		if (loading) return;
+		dispatch({
+			type: 'sync-sync-paid-payment-methods',
+			syncPaidPaymentMethods: value,
+		});
+	}, [loading, value]);
+	return [state, dispatch] as const;
+};
+
+export default useConsultationEditorState;
+
+const isZero = (x: string) => Number.parseInt(x, 10) === 0;
+const isValidAmount = (amount: string) => /^\d+$/.test(amount);
+const isRealBookNumber = (numberString: string) =>
+	books.isRealBookNumberStringRegex.test(numberString);
+const isValidInBookNumber = (numberString: string) =>
+	books.isValidInBookNumberStringRegex.test(numberString);
+
+const _initIsPaidDirty = ({
+	fields: {priceString, paidString},
+}: {
+	fields: Pick<State['fields'], 'priceString' | 'paidString'>;
+}) => priceString !== '' || paidString !== '';
+
+const _syncPaid = ({
+	fields: {payment_method},
+	config: {isPaidDirty, syncPaidPaymentMethods},
+}: {
+	fields: Pick<State['fields'], 'payment_method'>;
+	config: Pick<State['config'], 'isPaidDirty' | 'syncPaidPaymentMethods'>;
+}) => {
+	return !isPaidDirty && syncPaidPaymentMethods.includes(payment_method);
+};
+
+const init = (consultation: ConsultationEditorInit): State => {
+	const priceString = Number.isFinite(consultation.price)
+		? String(consultation.price)
+		: '';
+	const paidString = Number.isFinite(consultation.paid)
+		? String(consultation.paid)
+		: '';
+
+	const inBookNumberString =
+		Number.isInteger(consultation.inBookNumber) &&
+		consultation.inBookNumber !== undefined &&
+		consultation.inBookNumber >= 1
+			? String(consultation.inBookNumber)
+			: '';
+
+	const fields = {
+		...defaultState.fields,
+		...removeUndefined({
+			_id: consultation._id,
+			datetime: consultation.datetime,
+			doneDatetime: consultation.doneDatetime,
+			reason: consultation.reason,
+			done: consultation.done,
+			todo: consultation.todo,
+			treatment: consultation.treatment,
+			next: consultation.next,
+			more: consultation.more,
+
+			currency: consultation.currency,
+			payment_method: consultation.payment_method,
+			priceString,
+			paidString,
+			book: consultation.book,
+			inBookNumberString,
+		}),
+	};
+
+	const config = {
+		...defaultState.config,
+		...removeUndefined({
+			syncPaidPaymentMethods: [],
+			syncInBookNumber:
+				consultation._id === undefined && inBookNumberString === '',
+			priceWarning: isZero(priceString),
+			priceError: !isValidAmount(priceString),
+			paidError: !isValidAmount(paidString),
+			isPaidDirty: _initIsPaidDirty({fields}),
+			inBookNumberError: !isValidInBookNumber(inBookNumberString),
+			inBookNumberDisabled:
+				typeof consultation.book !== 'string' ||
+				!isRealBookNumber(consultation.book),
+		}),
+	};
+
+	const syncPaid = _syncPaid({
+		fields,
+		config,
+	});
+
+	return {
+		fields,
+		config: {
+			...config,
+			syncPaid,
+		},
+	};
+};
+
+type ConsultationFormFields = {
+	_id: string | undefined;
+	datetime: Date;
+	doneDatetime?: Date;
+	reason: string;
+	done?: string;
+	todo?: string;
+	treatment?: string;
+	next?: string;
+	more?: string;
+	currency: string;
+	payment_method: PaymentMethod;
+	priceString: string;
+	paidString: string;
+	book: string;
+	inBookNumberString: string;
+};
+
+type ConsultationFormConfiguration = {
+	lastInsertedId?: string;
+	syncPaid: boolean;
+	syncPaidPaymentMethods: PaymentMethod[];
+	syncInBookNumber: boolean;
+	loadingInBookNumber: boolean;
+	priceWarning: boolean;
+	priceError: boolean;
+	paidError: boolean;
+	inBookNumberError: boolean;
+	inBookNumberDisabled: boolean;
+	dirty: boolean;
+	isPaidDirty: boolean;
+	saving: boolean;
+	lastSaveWasSuccessful: boolean;
+};
+
+export type State = {
+	fields: ConsultationFormFields;
+	config: ConsultationFormConfiguration;
+};
+
+const defaultDate = '1970-01-01';
+const defaultTime = '00:00';
+
+const datetimeParse = (date: string, time: string) =>
+	dateParseISO(`${date}T${time}:00`);
+
+export const defaultState: State = {
+	fields: {
+		_id: undefined,
+		datetime: datetimeParse(defaultDate, defaultTime),
+		doneDatetime: undefined,
+		reason: '',
+		done: '',
+		todo: '',
+		treatment: '',
+		next: '',
+		more: '',
+
+		currency: 'EUR',
+		payment_method: 'cash',
+		priceString: '',
+		paidString: '',
+		book: '',
+		inBookNumberString: '',
+	},
+
+	config: {
+		syncPaid: true,
+		syncPaidPaymentMethods: [],
+		syncInBookNumber: false,
+		loadingInBookNumber: false,
+		priceWarning: false,
+		priceError: true,
+		paidError: true,
+		inBookNumberError: true,
+		inBookNumberDisabled: false,
+		dirty: false,
+		isPaidDirty: false,
+		saving: false,
+		lastSaveWasSuccessful: false,
+		lastInsertedId: undefined,
+	},
+};
+
+export type Action =
+	| {type: 'update'; key: keyof State['fields']; value: string}
+	| {type: 'save-success'; insertedId?: string}
+	| {type: 'sync-in-book-number'; inBookNumber: number}
+	| {
+			type: 'sync-sync-paid-payment-methods';
+			syncPaidPaymentMethods: PaymentMethod[];
+	  }
+	| {type: 'loading-next-in-book-number'}
+	| {type: 'disable-in-book-number'}
+	| {type: 'save'}
+	| {type: 'save-failure'}
+	| {type: 'not-dirty'};
+
+export const reducer = ({fields, config}: State, action: Action): State => {
+	switch (action.type) {
+		case 'update': {
+			switch (action.key) {
+				case '_id': {
+					throw new Error('Cannot update _id.');
+				}
+
+				case 'payment_method': {
+					const payment_method = action.value as PaymentMethod;
+					const newFields = {
+						...fields,
+						payment_method,
+					};
+					return {
+						fields: newFields,
+						config: {
+							...config,
+							syncPaid: _syncPaid({fields: newFields, config}),
+							dirty: true,
+						},
+					};
+				}
+
+				case 'paidString': {
+					const paidString = action.value;
+					return {
+						fields: {
+							...fields,
+							paidString,
+						},
+						config: {
+							...config,
+							paidError: !isValidAmount(paidString),
+							syncPaid: false,
+							dirty: true,
+							isPaidDirty: true,
+						},
+					};
+				}
+
+				case 'priceString': {
+					const priceString = action.value;
+					const paidString = config.syncPaid ? priceString : fields.paidString;
+					const isPaidDirty = config.isPaidDirty || paidString !== priceString;
+					return {
+						fields: {
+							...fields,
+							priceString,
+							paidString,
+						},
+						config: {
+							...config,
+							priceWarning: isZero(priceString),
+							priceError: !isValidAmount(priceString),
+							paidError: !isValidAmount(paidString),
+							dirty: true,
+							isPaidDirty,
+						},
+					};
+				}
+
+				case 'inBookNumberString': {
+					const inBookNumberString = action.value;
+					return {
+						fields: {
+							...fields,
+							inBookNumberString,
+						},
+						config: {
+							...config,
+							inBookNumberError: !isValidInBookNumber(inBookNumberString),
+							inBookNumberDisabled: !isRealBookNumber(fields.book),
+							syncInBookNumber: false,
+							dirty:
+								config.dirty ||
+								inBookNumberString !== fields.inBookNumberString,
+						},
+					};
+				}
+
+				default: {
+					if (
+						!Object.prototype.hasOwnProperty.call(
+							defaultState.fields,
+							action.key,
+						)
+					) {
+						throw new Error(`Unknown key ${action.key}`);
+					}
+
+					return {
+						fields: {
+							...fields,
+							[action.key]: action.value,
+						},
+						config: {
+							...config,
+							dirty: true,
+						},
+					};
+				}
+			}
+		}
+
+		case 'loading-next-in-book-number': {
+			return {
+				fields,
+				config: {
+					...config,
+					loadingInBookNumber: true,
+					inBookNumberDisabled: false,
+					syncInBookNumber: true,
+				},
+			};
+		}
+
+		case 'disable-in-book-number': {
+			return {
+				fields: {
+					...fields,
+					inBookNumberString: '',
+				},
+				config: {
+					...config,
+					inBookNumberError: false,
+					inBookNumberDisabled: true,
+					loadingInBookNumber: false,
+					syncInBookNumber: false,
+					dirty: config.dirty || fields.inBookNumberString !== '',
+				},
+			};
+		}
+
+		case 'sync-in-book-number': {
+			return {
+				fields: {
+					...fields,
+					inBookNumberString: String(action.inBookNumber),
+				},
+				config: {
+					...config,
+					inBookNumberError: false,
+					loadingInBookNumber: false,
+					syncInBookNumber: true,
+				},
+			};
+		}
+
+		case 'save': {
+			return {
+				fields,
+				config: {
+					...config,
+					saving: true,
+				},
+			};
+		}
+
+		case 'save-success': {
+			if (action.insertedId) {
+				return {
+					fields,
+					config: {
+						...config,
+						saving: false,
+						dirty: false,
+						lastSaveWasSuccessful: true,
+						lastInsertedId: action.insertedId,
+					},
+				};
+			}
+
+			return {
+				fields,
+				config: {
+					...config,
+					saving: false,
+					dirty: false,
+					lastSaveWasSuccessful: true,
+				},
+			};
+		}
+
+		case 'save-failure': {
+			return {
+				fields,
+				config: {
+					...config,
+					saving: false,
+					lastSaveWasSuccessful: false,
+				},
+			};
+		}
+
+		case 'not-dirty': {
+			return {
+				fields,
+				config: {
+					...config,
+					dirty: false,
+				},
+			};
+		}
+
+		case 'sync-sync-paid-payment-methods': {
+			const {syncPaidPaymentMethods} = action;
+			const {isPaidDirty} = config;
+
+			return {
+				fields,
+				config: {
+					...config,
+					syncPaidPaymentMethods,
+					syncPaid: _syncPaid({
+						fields,
+						config: {isPaidDirty, syncPaidPaymentMethods},
+					}),
+				},
+			};
+		}
+
+		default: {
+			// @ts-expect-error NOTE Can code defensively and be type-safe.
+			throw new Error(`Unknown action type ${action.type}.`);
+		}
+	}
+};

--- a/imports/ui/navigation/Loading.tsx
+++ b/imports/ui/navigation/Loading.tsx
@@ -12,6 +12,7 @@ const Loading = (props) => {
 	return (
 		<div>
 			<StyledAnimation
+				aria-label="loading"
 				type="bubbles"
 				color={theme.palette.primary.main}
 				height={400}

--- a/imports/ui/settings/CurrencySetting.tsx
+++ b/imports/ui/settings/CurrencySetting.tsx
@@ -7,7 +7,11 @@ import availableCurrencies, {
 
 import SelectOneSetting from './SelectOneSetting';
 
-const CurrencySetting = ({className}) => {
+type Props = {
+	readonly className?: string;
+};
+
+const CurrencySetting = ({className}: Props) => {
 	const options = [...availableCurrencies];
 	const optionToString = (option: AvailableCurrency) =>
 		currencyDescriptions[option];

--- a/imports/ui/settings/InputManySetting.tsx
+++ b/imports/ui/settings/InputManySetting.tsx
@@ -7,7 +7,7 @@ import SetPicker from '../input/SetPicker';
 import type PropsOf from '../../util/types/PropsOf';
 import {type SettingKey, type UserSettings} from '../../api/settings';
 
-import {useSetting} from './hooks';
+import {useSettingDebounced} from './hooks';
 
 type BaseProps<K extends SettingKey> = UserSettings[K] extends Array<infer V>
 	? {
@@ -16,7 +16,7 @@ type BaseProps<K extends SettingKey> = UserSettings[K] extends Array<infer V>
 			makeSuggestions?: (
 				value: UserSettings[K],
 			) => (x: string) => {loading?: boolean; results: UserSettings[K]};
-			title: string;
+			title?: string;
 			label?: string;
 			placeholder?: string;
 			itemToKey?: (x: V) => string;
@@ -43,7 +43,7 @@ const InputManySetting = <K extends SettingKey>({
 	sort = undefined,
 	...rest
 }: InputManySettingProps<K>) => {
-	const {loading, value, setValue} = useSetting(setting);
+	const {loading, value, setValue} = useSettingDebounced<K>(setting);
 
 	const onChange = useMemo(
 		() => async (e) => {
@@ -60,7 +60,7 @@ const InputManySetting = <K extends SettingKey>({
 
 	return (
 		<div className={className}>
-			<Typography variant="h4">{title}</Typography>
+			{title && <Typography variant="h4">{title}</Typography>}
 			<SetPicker
 				readOnly={loading}
 				useSuggestions={makeSuggestions(value)}

--- a/imports/ui/settings/Settings.tsx
+++ b/imports/ui/settings/Settings.tsx
@@ -26,6 +26,7 @@ import ThemePaletteModeSetting from './ThemePaletteModeSetting';
 import ThemePalettePrimarySetting from './ThemePalettePrimarySetting';
 import ThemePaletteSecondarySetting from './ThemePaletteSecondarySetting';
 import AgendaSlotClickSetsInitialTime from './AgendaSlotClickSetsInitialTime';
+import SyncPaidSetting from './SyncPaidSetting';
 
 const PREFIX = 'Settings';
 
@@ -78,9 +79,16 @@ export default function Settings() {
 					path="payment"
 					element={
 						<>
-							<AccountHolderSetting className={classes.setting} />
-							<IBANSetting className={classes.setting} />
-							<CurrencySetting className={classes.setting} />
+							<div className={classes.setting}>
+								<Typography variant="h4">Wire</Typography>
+								<AccountHolderSetting />
+								<IBANSetting />
+							</div>
+							<div className={classes.setting}>
+								<Typography variant="h4">Consultations</Typography>
+								<CurrencySetting />
+								<SyncPaidSetting />
+							</div>
 						</>
 					}
 				/>

--- a/imports/ui/settings/SyncPaidSetting.tsx
+++ b/imports/ui/settings/SyncPaidSetting.tsx
@@ -1,0 +1,57 @@
+import React, {useMemo} from 'react';
+
+import {filter} from '@iterable-iterator/filter';
+import {sorted} from '@iterable-iterator/sorted';
+
+import {key} from '@total-order/key';
+import {increasing} from '@total-order/primitive';
+
+import {type PaymentMethod} from '../../api/collection/consultations';
+
+import InputManySetting from './InputManySetting';
+
+const options = ['cash', 'wire', 'third-party'];
+
+type Props = {
+	readonly className?: string;
+};
+
+const SyncPaidSetting = ({className}: Props) => {
+	const optionToString = (option: PaymentMethod) => option;
+
+	const compare = useMemo(
+		() => key(increasing, (x: PaymentMethod) => options.indexOf(x)),
+		[options],
+	);
+
+	const sort = useMemo(
+		() => (items: PaymentMethod[]) => items.slice().sort(compare),
+		[compare],
+	);
+
+	const makeSuggestions = (value: PaymentMethod[]) => (inputValue: string) => ({
+		results: sorted(
+			compare,
+			filter(
+				(i: PaymentMethod) =>
+					!value.includes(i) &&
+					i.toLowerCase().startsWith(inputValue.toLowerCase()),
+				options,
+			),
+		),
+	});
+
+	return (
+		<InputManySetting
+			className={className}
+			label="Paid synchronization"
+			setting="consultations-paid-sync"
+			itemToString={optionToString}
+			createNewItem={undefined}
+			makeSuggestions={makeSuggestions}
+			sort={sort}
+		/>
+	);
+};
+
+export default SyncPaidSetting;

--- a/test/app/client/patient/appointments.app-tests.ts
+++ b/test/app/client/patient/appointments.app-tests.ts
@@ -16,6 +16,7 @@ import {
 	editConsultation,
 	fillIn,
 } from '../fixtures';
+import {setSetting} from '../../../../imports/ui/settings/hooks';
 
 const scheduleAppointmentForPatient = async (
 	app,
@@ -198,6 +199,8 @@ client(__filename, () => {
 		const password = randomPassword();
 		const app = setupApp();
 		await createUserWithPasswordAndLogin(username, password);
+
+		await setSetting('consultations-paid-sync', ['cash']);
 
 		const firstname = 'John';
 		const lastname = 'Doe';


### PR DESCRIPTION
- Fixes #692.

We implement the following:
- [x] Paid synchronization is opt-in for each payment method
- [x] Paid synchronization is only enabled when price and paid are uninitiated
- [x] A warning is displayed when paid value is different from price
- [x] An info message is displayed when paid value is identical to price 