### PR TITLE
Upgrade `bcrypt@6.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5028,12 +5028,12 @@
       "dev": true
     },
     "bcrypt": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
-      "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
       "requires": {
-        "@mapbox/node-pre-gyp": "^1.0.11",
-        "node-addon-api": "^5.0.0"
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
       }
     },
     "bl": {
@@ -12753,9 +12753,9 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.4.0.tgz",
+      "integrity": "sha512-D9DI/gXHvVmjHS08SVch0Em8G5S1P+QWtU31appcKT/8wFSPRcdHadIFSAntdMMVM5zz+/DL+bL/gz3UDppqtg=="
     },
     "node-domexception": {
       "version": "1.0.0",
@@ -12992,6 +12992,11 @@
           }
         }
       }
+    },
+    "node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="
     },
     "node-releases": {
       "version": "2.0.14",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@visx/scale": "^3.3.0",
     "@visx/shape": "^3.3.0",
     "@visx/tooltip": "^3.3.0",
-    "bcrypt": "^5.1.1",
+    "bcrypt": "^6.0.0",
     "canvas": "^2.11.2",
     "chardet": "^2.0.0",
     "colord": "^2.9.3",


### PR DESCRIPTION
`bcrypt@6.0.0` dropped support but all tests still pass. Sanity checks:
  - [x] We test user creation and login/logout.
  - [x] Meteor 2.16 only uses `bcrypt` in `packages/accounts-password/password_server.js`:
    - https://github.com/meteor/meteor/blob/97b721b415e73c072284404e800f9a4d1eb040ea/packages/accounts-password/password_server.js#L1
    - `import { hash as bcryptHash, compare as bcryptCompare } from 'bcrypt';`
    - `Accounts._bcryptRounds = () => Accounts._options.bcryptRounds || 10;`
    - `bcryptHash(string, number) -> X`
    - `if (!bcryptCompare(X, X)) ...`
  - [x] We do not depend on the package `npm-bcrypt` in `.meteor/versions` which is deprecated since Meteor 2.3:
    - https://v2-docs.meteor.com/changelog#v2320210624
  - [x] The following manual tests pass:

```sh
> meteor --version
Meteor 2.16
```

```sh
> meteor node --version
v14.21.4
```

```sh
> jq .version node_modules/bcrypt/package.json 
"6.0.0"
```

```sh
> meteor node -e 'console.debug(0.1 + 0.2)'
0.30000000000000004
```

```sh
> meteor node -e 'const {hash: bcryptHash, compare: bcryptCompare} = require("bcrypt"); console.debug({bcryptHash, bcryptCompare})'
{ bcryptHash: [Function: hash], bcryptCompare: [Function: compare] }
```

```sh
> meteor node -e 'const {hash: bcryptHash, compare: bcryptCompare} = require("bcrypt"); bcryptHash("abc123xyz", 12).then(console.debug)'
$2b$12$i9sg4Eld6ddbkLbD7nHjauzkTBIsmoaLEJ6wiJXD2wR1AmxKtTxtO
> meteor node -e 'const {hash: bcryptHash, compare: bcryptCompare} = require("bcrypt"); bcryptHash("abc123xyz", 12).then(console.debug)'
$2b$12$KwTijmdb6HYGItq/AFc1dey9ocBnBxrc6jGSJBMVNwfE1an.p5DRW
```

```sh
> meteor node -e 'const {hash: bcryptHash, compare: bcryptCompare} = require("bcrypt"); bcryptHash("abc123xyz", 12).then((hash) => bcryptCompare("abc123xyz", hash)).then(console.debug)'
true
```

```sh
> meteor node -e 'const {hash: bcryptHash, compare: bcryptCompare} = require("bcrypt"); bcryptHash("abc123xyy", 10).then((hash) => bcryptCompare("abc123xyz", hash)).then(console.debug)'
false
```
```